### PR TITLE
feat: Add dashboard home page

### DIFF
--- a/src/renderer/app/layouts/Sidebar.tsx
+++ b/src/renderer/app/layouts/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   BarChart3,
   Bot,
   GitBranch,
+  Home,
   LayoutDashboard,
   Lightbulb,
   ListTodo,
@@ -82,6 +83,27 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 p-2">
+        {/* Dashboard — top-level, not project-scoped */}
+        <button
+          title={sidebarCollapsed ? 'Dashboard' : undefined}
+          className={cn(
+            'flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-sm transition-colors',
+            'hover:bg-accent hover:text-foreground',
+            currentPath === ROUTES.DASHBOARD
+              ? 'bg-accent text-foreground font-medium'
+              : 'text-muted-foreground',
+            sidebarCollapsed && 'justify-center px-0',
+          )}
+          onClick={() => void navigate({ to: ROUTES.DASHBOARD })}
+        >
+          <Home className="h-4 w-4 shrink-0" />
+          {!sidebarCollapsed && <span>Dashboard</span>}
+        </button>
+
+        {/* Divider */}
+        <div className="border-border my-1 border-t" />
+
+        {/* Project views */}
         {navItems.map((item) => {
           const isActive = currentPath.includes(`/${item.path}`);
           return (

--- a/src/renderer/app/router.tsx
+++ b/src/renderer/app/router.tsx
@@ -18,6 +18,7 @@ import { ROUTES, ROUTE_PATTERNS } from '@shared/constants';
 // Feature page components
 import { AgentDashboard } from '@features/agents';
 import { ChangelogPage } from '@features/changelog';
+import { DashboardPage } from '@features/dashboard';
 import { GitHubPage } from '@features/github';
 import { IdeationPage } from '@features/ideation';
 import { InsightsPage } from '@features/insights';
@@ -42,8 +43,16 @@ const indexRoute = createRoute({
   path: ROUTES.INDEX,
   beforeLoad: () => {
     // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router redirect pattern
-    throw redirect({ to: ROUTES.PROJECTS });
+    throw redirect({ to: ROUTES.DASHBOARD });
   },
+});
+
+// ─── Dashboard ──────────────────────────────────────────────
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTES.DASHBOARD,
+  component: DashboardPage,
 });
 
 // ─── Projects ────────────────────────────────────────────────
@@ -137,6 +146,7 @@ const settingsRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  dashboardRoute,
   projectsRoute,
   projectRoute,
   kanbanRoute,

--- a/src/renderer/features/dashboard/api/queryKeys.ts
+++ b/src/renderer/features/dashboard/api/queryKeys.ts
@@ -1,0 +1,7 @@
+/**
+ * Dashboard query keys factory
+ */
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+  stats: () => [...dashboardKeys.all, 'stats'] as const,
+};

--- a/src/renderer/features/dashboard/api/useDashboard.ts
+++ b/src/renderer/features/dashboard/api/useDashboard.ts
@@ -1,0 +1,9 @@
+/**
+ * React Query hooks for dashboard data
+ *
+ * Re-exports project and agent hooks for dashboard consumption.
+ * Dashboard-specific queries can be added here as the feature grows.
+ */
+
+export { useProjects } from '@features/projects';
+export { useAgents } from '@features/agents';

--- a/src/renderer/features/dashboard/components/ActiveAgents.tsx
+++ b/src/renderer/features/dashboard/components/ActiveAgents.tsx
@@ -1,0 +1,90 @@
+/**
+ * ActiveAgents — Shows running agents across all projects
+ */
+
+import { Bot, CheckCircle2, Loader2, XCircle } from 'lucide-react';
+
+import type { AgentStatus } from '@shared/types';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+type MockAgentStatus = Extract<AgentStatus, 'running' | 'completed' | 'error'>;
+
+interface MockAgent {
+  id: string;
+  projectName: string;
+  taskName: string;
+  status: MockAgentStatus;
+  progress: number;
+}
+
+const STATUS_CONFIG: Record<MockAgentStatus, { icon: typeof Loader2; className: string }> = {
+  running: { icon: Loader2, className: 'text-blue-400' },
+  completed: { icon: CheckCircle2, className: 'text-green-400' },
+  error: { icon: XCircle, className: 'text-red-400' },
+};
+
+/** Placeholder agent data */
+const MOCK_AGENTS: MockAgent[] = [
+  {
+    id: 'ma-1',
+    projectName: 'Claude-UI',
+    taskName: 'Build dashboard feature',
+    status: 'running',
+    progress: 65,
+  },
+  {
+    id: 'ma-2',
+    projectName: 'API Server',
+    taskName: 'Fix auth middleware',
+    status: 'running',
+    progress: 30,
+  },
+];
+
+export function ActiveAgents() {
+  return (
+    <div className="bg-card border-border rounded-lg border p-4">
+      <h2 className="text-foreground mb-3 text-sm font-semibold">Active Agents</h2>
+
+      {MOCK_AGENTS.length > 0 ? (
+        <div className="space-y-3">
+          {MOCK_AGENTS.map((agent) => {
+            const config = STATUS_CONFIG[agent.status];
+            const StatusIcon = config.icon;
+
+            return (
+              <div key={agent.id} className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <StatusIcon
+                      className={cn(
+                        'h-3.5 w-3.5',
+                        config.className,
+                        agent.status === 'running' && 'animate-spin',
+                      )}
+                    />
+                    <span className="text-foreground text-xs font-medium">{agent.projectName}</span>
+                  </div>
+                  <span className="text-muted-foreground text-xs">{agent.progress}%</span>
+                </div>
+                <p className="text-muted-foreground truncate pl-5.5 text-xs">{agent.taskName}</p>
+                <div className="ml-5.5 h-1 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full rounded-full bg-blue-500 transition-all"
+                    style={{ width: `${String(agent.progress)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="py-6 text-center">
+          <Bot className="text-muted-foreground mx-auto mb-2 h-8 w-8" />
+          <p className="text-muted-foreground text-xs">No agents running</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/DailyStats.tsx
+++ b/src/renderer/features/dashboard/components/DailyStats.tsx
@@ -1,0 +1,25 @@
+/**
+ * DailyStats — Simple stats row showing daily activity
+ */
+
+import { useDashboardStore } from '../store';
+
+export function DailyStats() {
+  const captureCount = useDashboardStore((s) => s.quickCaptures.length);
+
+  // Mock values for tasks and agents until real data is available
+  const tasksCompleted = 0;
+  const agentsRan = 2;
+
+  return (
+    <div className="bg-card border-border rounded-lg border px-4 py-3">
+      <p className="text-muted-foreground text-xs">
+        <span className="text-foreground font-medium">{tasksCompleted}</span> tasks completed
+        {' \u00B7 '}
+        <span className="text-foreground font-medium">{agentsRan}</span> agents ran
+        {' \u00B7 '}
+        <span className="text-foreground font-medium">{captureCount}</span> captures
+      </p>
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/DashboardPage.tsx
+++ b/src/renderer/features/dashboard/components/DashboardPage.tsx
@@ -1,0 +1,44 @@
+/**
+ * DashboardPage — Main dashboard layout composing all widgets
+ */
+
+import { useDashboardEvents } from '../hooks/useDashboardEvents';
+
+import { ActiveAgents } from './ActiveAgents';
+import { DailyStats } from './DailyStats';
+import { GreetingHeader } from './GreetingHeader';
+import { QuickCapture } from './QuickCapture';
+import { RecentProjects } from './RecentProjects';
+import { TodayView } from './TodayView';
+
+export function DashboardPage() {
+  useDashboardEvents();
+
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto max-w-5xl">
+        {/* Greeting */}
+        <GreetingHeader />
+
+        {/* Row 1: Today + Recent Projects */}
+        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-5">
+          <div className="md:col-span-2">
+            <TodayView />
+          </div>
+          <div className="md:col-span-3">
+            <RecentProjects />
+          </div>
+        </div>
+
+        {/* Row 2: Active Agents + Quick Capture & Stats */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <ActiveAgents />
+          <div className="space-y-4">
+            <QuickCapture />
+            <DailyStats />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/GreetingHeader.tsx
+++ b/src/renderer/features/dashboard/components/GreetingHeader.tsx
@@ -1,0 +1,42 @@
+/**
+ * GreetingHeader — Time-aware greeting with current date
+ */
+
+import { useEffect, useState } from 'react';
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+function formatDate(): string {
+  return new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export function GreetingHeader() {
+  const [greeting, setGreeting] = useState(getGreeting);
+  const [date, setDate] = useState(formatDate);
+
+  useEffect(() => {
+    // Update greeting and date every minute
+    const interval = setInterval(() => {
+      setGreeting(getGreeting());
+      setDate(formatDate());
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h1 className="text-foreground text-2xl font-bold">{greeting}</h1>
+      <p className="text-muted-foreground mt-1 text-sm">{date}</p>
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/QuickCapture.tsx
+++ b/src/renderer/features/dashboard/components/QuickCapture.tsx
@@ -1,0 +1,87 @@
+/**
+ * QuickCapture — Quick text input for ideas, tasks, and notes
+ */
+
+import { useState } from 'react';
+
+import { Plus, X } from 'lucide-react';
+
+import { cn, formatRelativeTime } from '@renderer/shared/lib/utils';
+
+import { useDashboardStore } from '../store';
+
+const MAX_RECENT = 5;
+
+export function QuickCapture() {
+  const [inputValue, setInputValue] = useState('');
+  const { quickCaptures, addCapture, removeCapture } = useDashboardStore();
+
+  function handleSubmit() {
+    const trimmed = inputValue.trim();
+    if (trimmed.length === 0) return;
+    addCapture(trimmed);
+    setInputValue('');
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      handleSubmit();
+    }
+  }
+
+  const recentCaptures = quickCaptures.slice(0, MAX_RECENT);
+
+  return (
+    <div className="bg-card border-border rounded-lg border p-4">
+      <h2 className="text-foreground mb-3 text-sm font-semibold">Quick Capture</h2>
+
+      <div className="flex gap-2">
+        <input
+          placeholder="Quick idea, task, or note..."
+          type="text"
+          value={inputValue}
+          className={cn(
+            'border-border bg-background text-foreground flex-1 rounded-md border px-3 py-1.5 text-sm',
+            'placeholder:text-muted-foreground',
+            'focus:ring-ring focus:ring-1 focus:outline-none',
+          )}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          disabled={inputValue.trim().length === 0}
+          className={cn(
+            'bg-primary text-primary-foreground rounded-md px-3 py-1.5',
+            'hover:bg-primary/90 transition-colors',
+            'disabled:pointer-events-none disabled:opacity-50',
+          )}
+          onClick={handleSubmit}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+
+      {recentCaptures.length > 0 && (
+        <ul className="mt-3 space-y-1.5">
+          {recentCaptures.map((capture) => (
+            <li
+              key={capture.id}
+              className="border-border flex items-start gap-2 rounded-md border px-3 py-2"
+            >
+              <p className="text-foreground min-w-0 flex-1 text-xs">{capture.text}</p>
+              <span className="text-muted-foreground shrink-0 text-xs">
+                {formatRelativeTime(capture.createdAt)}
+              </span>
+              <button
+                className="text-muted-foreground hover:text-foreground shrink-0"
+                onClick={() => removeCapture(capture.id)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/RecentProjects.tsx
+++ b/src/renderer/features/dashboard/components/RecentProjects.tsx
@@ -1,0 +1,71 @@
+/**
+ * RecentProjects — Grid of recently used project cards
+ */
+
+import { useNavigate } from '@tanstack/react-router';
+import { FolderOpen, Loader2 } from 'lucide-react';
+
+import { PROJECT_VIEWS, projectViewPath } from '@shared/constants';
+
+import { cn, formatRelativeTime, truncate } from '@renderer/shared/lib/utils';
+import { useLayoutStore } from '@renderer/shared/stores';
+
+import { useProjects } from '@features/projects';
+
+export function RecentProjects() {
+  const navigate = useNavigate();
+  const { data: projects, isLoading } = useProjects();
+  const { addProjectTab } = useLayoutStore();
+
+  function handleOpenProject(projectId: string) {
+    addProjectTab(projectId);
+    void navigate({ to: projectViewPath(projectId, PROJECT_VIEWS.KANBAN) });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-card border-border flex items-center justify-center rounded-lg border p-8">
+        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  const projectList = projects ?? [];
+
+  return (
+    <div className="bg-card border-border rounded-lg border p-4">
+      <h2 className="text-foreground mb-3 text-sm font-semibold">Recent Projects</h2>
+
+      {projectList.length > 0 ? (
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {projectList.map((project) => (
+            <button
+              key={project.id}
+              className={cn(
+                'border-border flex items-start gap-3 rounded-md border p-3 text-left',
+                'hover:bg-accent transition-colors',
+              )}
+              onClick={() => handleOpenProject(project.id)}
+            >
+              <FolderOpen className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="text-foreground truncate text-sm font-medium">{project.name}</p>
+                <p className="text-muted-foreground truncate text-xs">
+                  {truncate(project.path, 40)}
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  {formatRelativeTime(project.updatedAt)}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="py-6 text-center">
+          <FolderOpen className="text-muted-foreground mx-auto mb-2 h-8 w-8" />
+          <p className="text-muted-foreground text-xs">No projects yet</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/components/TodayView.tsx
+++ b/src/renderer/features/dashboard/components/TodayView.tsx
@@ -1,0 +1,83 @@
+/**
+ * TodayView — Compact daily planner with time blocks
+ */
+
+import { cn } from '@renderer/shared/lib/utils';
+
+type TimeBlockCategory = 'work' | 'side-project' | 'personal';
+
+interface TimeBlock {
+  id: string;
+  time: string;
+  label: string;
+  category: TimeBlockCategory;
+}
+
+const CATEGORY_COLORS: Record<TimeBlockCategory, string> = {
+  work: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+  'side-project': 'bg-green-500/15 text-green-400 border-green-500/30',
+  personal: 'bg-purple-500/15 text-purple-400 border-purple-500/30',
+};
+
+const CATEGORY_DOT_COLORS: Record<TimeBlockCategory, string> = {
+  work: 'bg-blue-400',
+  'side-project': 'bg-green-400',
+  personal: 'bg-purple-400',
+};
+
+/** Placeholder schedule data */
+const MOCK_TIME_BLOCKS: TimeBlock[] = [
+  { id: 'tb-1', time: '9:00 AM', label: 'Daily standup', category: 'work' },
+  { id: 'tb-2', time: '10:00 AM', label: 'Feature development', category: 'work' },
+  { id: 'tb-3', time: '1:00 PM', label: 'Claude-UI dashboard', category: 'side-project' },
+  { id: 'tb-4', time: '3:00 PM', label: 'Code review', category: 'work' },
+  { id: 'tb-5', time: '5:30 PM', label: 'Gym', category: 'personal' },
+];
+
+export function TodayView() {
+  return (
+    <div className="bg-card border-border rounded-lg border p-4">
+      <h2 className="text-foreground mb-3 text-sm font-semibold">Today</h2>
+
+      {MOCK_TIME_BLOCKS.length > 0 ? (
+        <div className="space-y-2">
+          {MOCK_TIME_BLOCKS.map((block) => (
+            <div
+              key={block.id}
+              className={cn(
+                'flex items-center gap-3 rounded-md border px-3 py-2 text-xs',
+                CATEGORY_COLORS[block.category],
+              )}
+            >
+              <span className="w-16 shrink-0 font-mono opacity-80">{block.time}</span>
+              <span
+                className={cn(
+                  'h-1.5 w-1.5 shrink-0 rounded-full',
+                  CATEGORY_DOT_COLORS[block.category],
+                )}
+              />
+              <span className="truncate font-medium">{block.label}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground py-4 text-center text-xs">Nothing scheduled today</p>
+      )}
+
+      <div className="mt-3 flex gap-4 border-t border-white/5 pt-3">
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="h-2 w-2 rounded-full bg-blue-400" />
+          <span className="text-muted-foreground">Work</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="h-2 w-2 rounded-full bg-green-400" />
+          <span className="text-muted-foreground">Side project</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="h-2 w-2 rounded-full bg-purple-400" />
+          <span className="text-muted-foreground">Personal</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/dashboard/hooks/useDashboardEvents.ts
+++ b/src/renderer/features/dashboard/hooks/useDashboardEvents.ts
@@ -1,0 +1,13 @@
+/**
+ * Dashboard IPC event listeners -> query invalidation
+ *
+ * Listens for project and agent events to keep dashboard data fresh.
+ */
+
+import { useAgentEvents } from '@features/agents';
+import { useProjectEvents } from '@features/projects';
+
+export function useDashboardEvents() {
+  useProjectEvents();
+  useAgentEvents();
+}

--- a/src/renderer/features/dashboard/index.ts
+++ b/src/renderer/features/dashboard/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard feature — public API
+ */
+
+// Components
+export { DashboardPage } from './components/DashboardPage';
+
+// Store
+export { useDashboardStore } from './store';
+
+// API
+export { dashboardKeys } from './api/queryKeys';
+
+// Events
+export { useDashboardEvents } from './hooks/useDashboardEvents';

--- a/src/renderer/features/dashboard/store.ts
+++ b/src/renderer/features/dashboard/store.ts
@@ -1,0 +1,38 @@
+/**
+ * Dashboard Store — UI state for the dashboard feature
+ */
+
+import { create } from 'zustand';
+
+interface QuickCapture {
+  id: string;
+  text: string;
+  createdAt: string;
+}
+
+interface DashboardState {
+  quickCaptures: QuickCapture[];
+  addCapture: (text: string) => void;
+  removeCapture: (id: string) => void;
+}
+
+export const useDashboardStore = create<DashboardState>((set) => ({
+  quickCaptures: [],
+
+  addCapture: (text) =>
+    set((state) => ({
+      quickCaptures: [
+        {
+          id: crypto.randomUUID(),
+          text,
+          createdAt: new Date().toISOString(),
+        },
+        ...state.quickCaptures,
+      ],
+    })),
+
+  removeCapture: (id) =>
+    set((state) => ({
+      quickCaptures: state.quickCaptures.filter((capture) => capture.id !== id),
+    })),
+}));

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -8,6 +8,7 @@
 /** Top-level routes */
 export const ROUTES = {
   INDEX: '/',
+  DASHBOARD: '/dashboard',
   PROJECTS: '/projects',
   SETTINGS: '/settings',
 } as const;


### PR DESCRIPTION
## Summary
- New `dashboard` feature module with 7 components (GreetingHeader, TodayView, RecentProjects, ActiveAgents, QuickCapture, DailyStats, DashboardPage)
- New `/dashboard` route — now the app's home screen (index redirects here)
- Dashboard nav item with Home icon added to sidebar (above project views, with divider)
- Zustand store for quick captures
- Uses real project data via existing `useProjects()` hook

## Files
- 12 new files in `src/renderer/features/dashboard/`
- 3 modified: `router.tsx`, `Sidebar.tsx`, `routes.ts`

## Test plan
- [ ] `npm run dev` — dashboard loads as home screen
- [ ] Project cards show real projects with click-to-navigate
- [ ] Quick capture input stores and displays entries
- [ ] Sidebar Dashboard button navigates to `/dashboard`
- [ ] Responsive layout works at various window sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)