### PR TITLE
feat(team-beta): frontend UI implementation — task table, auth, workspaces, wizard, hub wiring

### DIFF
--- a/src/main/services/agent/agent-queue.ts
+++ b/src/main/services/agent/agent-queue.ts
@@ -1,6 +1,9 @@
 /**
  * Agent Queue — Priority FIFO Queue for Agent Execution
  *
+ * @deprecated Part of the legacy agent system. The new workflow/task-launcher.ts
+ * handles session management directly. Kept for backward compatibility.
+ *
  * Manages queued agents with configurable max concurrency.
  * Agents are dequeued by priority (higher = more priority),
  * with FIFO ordering within the same priority level.

--- a/src/main/services/agent/agent-service.ts
+++ b/src/main/services/agent/agent-service.ts
@@ -1,6 +1,10 @@
 /**
  * Agent Service — Claude CLI Process Management
  *
+ * @deprecated Use workflow/task-launcher.ts instead. This legacy agent service
+ * spawns PTY-based agents. The new TaskLauncher uses detached child_process
+ * for simpler lifecycle management. Kept for backward compatibility.
+ *
  * Spawns and manages Claude CLI agents for task execution.
  * Agents run in dedicated terminals and their output is parsed
  * for status updates, progress, and logs.

--- a/src/main/services/agent/token-parser.ts
+++ b/src/main/services/agent/token-parser.ts
@@ -1,6 +1,9 @@
 /**
  * Token Parser — Extract token usage from Claude CLI output
  *
+ * @deprecated Part of the legacy agent system. The new workflow/task-launcher.ts
+ * delegates token tracking to the Hub backend. Kept for backward compatibility.
+ *
  * Parses various output formats from Claude CLI to extract
  * input/output token counts and cost information.
  *


### PR DESCRIPTION
## Summary

Complete Team Beta Frontend implementation across 4 waves, executing the plan at `docs/plans/TEAM-BETA-FRONTEND.md`.

**Note:** Most of this work was already merged to master via earlier PRs. After rebasing, the remaining delta is deprecation markers on legacy agent code. This PR serves as the formal close-out of the Team Beta plan.

### Wave 1: Task Table & Project Detection
- **TaskTable, TaskTableRow, TaskTableHeader, TaskTableFilters** — sortable/filterable table replacing Kanban board
- **project-detector.ts** — identifies single/monorepo/multi-repo structures, finds child git repos
- IPC channel `projects.detectRepo` wired with Zod schemas

### Wave 2: Auth UI & Settings
- **Auth module** — LoginPage, RegisterPage, auth-store (Zustand), useAuth hooks, stub IPC handlers
- **Workspaces settings** — WorkspacesTab, WorkspaceCard, WorkspaceEditor, DeviceSelector
- **Project Init Wizard** — 5-step wizard with RepoTypeSelector, SubRepoDetector, SubRepoSelector
- 11 new IPC channels (5 auth + 5 workspace + 1 device)

### Wave 3: Hub API Wiring
- **hub-api-client.ts** — typed HTTP client using `node:http`/`node:https` (zero external deps)
- **progress-watcher.ts** — watches `docs/progress/*.md` with `fs.watch()`, parses YAML frontmatter
- **progress-syncer.ts** — pushes progress data to Hub API
- 5 workflow IPC channels

### Wave 4: Launcher & Cleanup
- **task-launcher.ts** — spawns detached `claude` CLI processes for autonomous task execution
- **Kanban deletion** — entire `kanban/` directory removed, all references updated
- **Agent deprecation** — `@deprecated` JSDoc on agent-service, agent-queue, token-parser
- Router, sidebar, topbar updated to use TaskTable

### Audit Results
All 16 plan deliverables verified complete. See `docs/progress/team-beta-progress.md`.

## Test plan
- [x] `npm run lint` — zero violations
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — successful (main: 375.84 kB, renderer: 2,143.33 kB)
- [x] All 4 waves verified against plan checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)