### PR TITLE
feat: Wire agent watchdog + QA events (Phase 1 completion)

### DIFF
--- a/ai-docs/FEATURES-INDEX.md
+++ b/ai-docs/FEATURES-INDEX.md
@@ -39,7 +39,7 @@ Location: `src/renderer/features/`
 | **projects** | Project management | ProjectListPage, ProjectSettings, WorktreeManager, ProjectEditDialog | `projects.*` |
 | **roadmap** | Project roadmap | RoadmapPage, MilestoneCard | `milestones.*` |
 | **settings** | App settings | SettingsPage, HubSettings, OAuthProviderSettings, WebhookSettings | `settings.*` |
-| **tasks** | Task management (AG-Grid dashboard) | TaskDataGrid, TaskFiltersToolbar, TaskDetailRow, TaskStatusBadge, CreateTaskDialog | `hub.tasks.*`, `tasks.*` |
+| **tasks** | Task management (AG-Grid dashboard) | TaskDataGrid, TaskFiltersToolbar, TaskDetailRow, TaskStatusBadge, CreateTaskDialog; **Hooks**: useTaskEvents (→ useAgentEvents + useQaEvents), useAgentMutations, useQaMutations, QaReportViewer | `hub.tasks.*`, `tasks.*`, `agent.*`, `qa.*`, `event:agent.orchestrator.*`, `event:qa.*` |
 | **terminals** | Terminal emulator | TerminalGrid, TerminalInstance | `terminals.*` |
 | **briefing** | Daily briefing & suggestions | BriefingPage, SuggestionCard | `briefing.*` |
 | **merge** | Branch merge workflow | ConflictResolver, MergeConfirmModal, MergePreviewPanel | `merge.*` |
@@ -115,8 +115,8 @@ Location: `src/main/services/`
 | **device/heartbeat** | Periodic heartbeat pings to Hub | start, stop | - |
 | **agent-orchestrator** | Headless Claude agent lifecycle management | spawnSession, stopSession, listSessions, onSessionEvent | `event:agent.orchestrator.*` |
 | **agent-orchestrator/jsonl-progress-watcher** | JSONL progress file watcher (debounced tail parsing) | start, stop, onProgress | `event:agent.orchestrator.progress`, `event:agent.orchestrator.planReady` |
-| **agent-orchestrator/agent-watchdog** | Health monitoring for active agent sessions | createAgentWatchdog | - |
-| **qa** | Two-tier automated QA system (quiet + full) | runQuiet, runFull, getReports | `event:assistant.proactive` (on failure) |
+| **agent-orchestrator/agent-watchdog** | Health monitoring for active agent sessions (PID checks, heartbeat age, auto-restart on overflow) | start, stop, checkNow, onAlert, dispose | `event:agent.orchestrator.watchdogAlert` (wired in index.ts) |
+| **qa** | Two-tier automated QA system (quiet + full) | startQuiet, startFull, getSession, getReportForTask, cancel, onSessionEvent | `event:qa.started`, `event:qa.progress`, `event:qa.completed` |
 | **assistant/watch-store** | Persistent watch subscription storage (JSON file) | add, remove, getActive, getAll, markTriggered, clear | - |
 | **assistant/watch-evaluator** | Evaluates IPC events against active watches | start, stop, onTrigger | `event:assistant.proactive` (via index.ts wiring) |
 | **assistant/cross-device-query** | Query other ADC instances via Hub API | query | - |

--- a/src/renderer/features/tasks/hooks/useQaEvents.ts
+++ b/src/renderer/features/tasks/hooks/useQaEvents.ts
@@ -1,0 +1,48 @@
+/**
+ * QA IPC event listeners → query invalidation
+ *
+ * Bridges real-time QA events from the main process to React Query cache.
+ * Provides instant feedback when QA sessions start, progress, or complete.
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useIpcEvent } from '@renderer/shared/hooks';
+import { useToastStore } from '@renderer/shared/stores';
+
+import { taskKeys } from '../api/queryKeys';
+
+const qaKeys = {
+  all: ['qa'] as const,
+  report: (taskId: string) => [...qaKeys.all, 'report', taskId] as const,
+  session: (taskId: string) => [...qaKeys.all, 'session', taskId] as const,
+};
+
+export function useQaEvents() {
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+
+  // QA session started → invalidate session cache for live status
+  useIpcEvent('event:qa.started', (data) => {
+    void queryClient.invalidateQueries({ queryKey: qaKeys.session(data.taskId) });
+  });
+
+  // QA progress → invalidate session cache for live step tracking
+  useIpcEvent('event:qa.progress', (data) => {
+    void queryClient.invalidateQueries({ queryKey: qaKeys.session(data.taskId) });
+  });
+
+  // QA completed → invalidate report + session + task caches, show toast
+  useIpcEvent('event:qa.completed', (data) => {
+    void queryClient.invalidateQueries({ queryKey: qaKeys.report(data.taskId) });
+    void queryClient.invalidateQueries({ queryKey: qaKeys.session(data.taskId) });
+    void queryClient.invalidateQueries({ queryKey: taskKeys.detail(data.taskId) });
+    void queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+
+    const isPassing = data.result === 'pass';
+    addToast(
+      `QA ${isPassing ? 'passed' : 'failed'} for task (${String(data.issueCount)} issues)`,
+      isPassing ? 'success' : 'error',
+    );
+  });
+}

--- a/src/renderer/features/tasks/hooks/useTaskEvents.ts
+++ b/src/renderer/features/tasks/hooks/useTaskEvents.ts
@@ -15,10 +15,13 @@ import { useToastStore } from '@renderer/shared/stores';
 import { taskKeys } from '../api/queryKeys';
 
 import { useAgentEvents } from './useAgentEvents';
+import { useQaEvents } from './useQaEvents';
 
 export function useTaskEvents() {
   // Agent orchestrator events (planning, execution, watchdog)
   useAgentEvents();
+  // QA session events (started, progress, completed)
+  useQaEvents();
   const queryClient = useQueryClient();
 
   // ── Local task events ──

--- a/src/renderer/features/tasks/index.ts
+++ b/src/renderer/features/tasks/index.ts
@@ -16,11 +16,19 @@ export {
   useKillAgent,
   useRestartFromCheckpoint,
 } from './api/useAgentMutations';
+export {
+  useQaReport,
+  useQaSession,
+  useStartQuietQa,
+  useStartFullQa,
+  useCancelQa,
+} from './api/useQaMutations';
 export { taskKeys } from './api/queryKeys';
 
 // Events
 export { useTaskEvents } from './hooks/useTaskEvents';
 export { useAgentEvents } from './hooks/useAgentEvents';
+export { useQaEvents } from './hooks/useQaEvents';
 
 // Store
 export { useTaskUI } from './store';


### PR DESCRIPTION
## Summary

Phase 1 (Agent Spawn Infrastructure) from the Three Pillars design was ~95% implemented. This PR closes the three remaining wiring gaps for complete frontend-to-backend connectivity:

- **Agent Watchdog started** — `createAgentWatchdog` existed as a service but was never instantiated in `index.ts`. Now created, wired to emit `event:agent.orchestrator.watchdogAlert` IPC events, started on app init, and disposed on quit. Monitors active agent sessions with 30s PID checks, heartbeat age thresholds (5min warn, 15min stale), and alert deduplication.

- **QA events consumed in renderer** — `event:qa.started/progress/completed` were emitted by QA handlers but had no renderer listener. Added `useQaEvents` hook with cache invalidation + toast notifications, wired into the `useTaskEvents` chain so TaskDataGrid gets real-time QA updates.

- **Documentation updated** — `ARCHITECTURE.md`, `DATA-FLOW.md`, and `FEATURES-INDEX.md` now cover the complete orchestrator lifecycle, watchdog wiring, QA event chain, and renderer integration details.

## Files Changed

| File | Change |
|------|--------|
| `src/main/index.ts` | Wire watchdog creation, alert forwarding, start, cleanup |
| `src/renderer/features/tasks/hooks/useQaEvents.ts` | **New** — 3 QA event listeners → cache + toast |
| `src/renderer/features/tasks/hooks/useTaskEvents.ts` | Import and call useQaEvents |
| `src/renderer/features/tasks/index.ts` | Export QA hooks and useQaEvents |
| `ai-docs/ARCHITECTURE.md` | Expanded orchestrator + QA system docs |
| `ai-docs/DATA-FLOW.md` | Replaced outdated agent flow, added QA event chain |
| `ai-docs/FEATURES-INDEX.md` | Updated watchdog + QA descriptions |

## Test plan

- [x] `npm run lint` — zero violations
- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 182 passing (107 unit + 75 integration)
- [x] `npm run build` — success
- [x] `npm run check:docs` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)