### PR TITLE
feat: Wire QA auto-trigger service

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -227,6 +227,7 @@ Two-tier automated QA system that spawns Claude agents via the orchestrator:
 - **QaRunner** (`qa-runner.ts`) — Session management, uses `orchestrator.spawn()` with `phase: 'qa'`
 - **QaReportParser** (`qa-report-parser.ts`) — Parses structured JSON report from agent output
 - **QaHandlers** (`qa-handlers.ts`) — 5 IPC channels (startQuiet, startFull, getReport, getSession, cancel)
+- **QaTrigger** (`qa-trigger.ts`) — Auto-starts quiet QA when an execution agent completes; listens for orchestrator session completion events where `phase === 'executing'`, waits 2s for status propagation, then starts quiet QA if task is in 'review' status. Guards against re-triggering via taskId tracking.
 
 ### IPC Event Channels (3 events)
 

--- a/ai-docs/DATA-FLOW.md
+++ b/ai-docs/DATA-FLOW.md
@@ -347,6 +347,28 @@ Agent runs (writes JSONL progress to {dataDir}/progress/{taskId}.jsonl)
       useAgentEvents → full task cache invalidation
 ```
 
+### QA Auto-Trigger Flow
+
+```
+Agent execution completes (orchestrator session event):
+  |
+  v
+qaTrigger listens for session completion              qa-trigger.ts
+  where event.type === 'completed'
+  and event.session.phase === 'executing'
+  |
+  v
+Wait 2 seconds (status propagation delay)
+  |
+  v
+Check: task status === 'review'?
+  Yes → qaRunner.startQuiet(taskId, context)
+  No  → skip (task may have been manually updated)
+  |
+  (guards: skip if already triggered for this taskId,
+   skip if QA session already active)
+```
+
 ### QA Runner Flow
 
 ```


### PR DESCRIPTION
## Summary
- Wire `createQaTrigger` in `src/main/index.ts` — the service existed but was never instantiated
- QA auto-trigger listens for orchestrator session completion events where `phase === 'executing'`, waits 2s for status propagation, then auto-starts quiet QA if the task is in `review` status
- Added cleanup disposal in the `before-quit` handler
- Updated `ARCHITECTURE.md` and `DATA-FLOW.md` with QA auto-trigger documentation

## Test plan
- [x] `npm run lint` — zero violations
- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 75/75 passing
- [x] `npm run build` — successful
- [x] `npm run check:docs` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)