### PR TITLE
feat: Wire complete task planning pipeline

### DIFF
--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -1,0 +1,158 @@
+# /plan-feature — Deep Technical Planning
+
+> Generate a detailed implementation plan for a feature. Analyzes the codebase, designs an approach, decomposes into tasks, and writes the plan to a predictable file path for orchestrator detection.
+
+**Usage:** `/plan-feature <feature description>`
+
+---
+
+## Phase 1: Load Context
+
+Read these files to understand the system:
+
+```
+MANDATORY READS:
+1. CLAUDE.md                       — Project rules, tech stack, patterns
+2. ai-docs/ARCHITECTURE.md         — System architecture, IPC flow
+3. ai-docs/PATTERNS.md             — Code conventions, component patterns
+4. ai-docs/FEATURES-INDEX.md       — Existing features inventory
+5. ai-docs/DATA-FLOW.md            — Data flow diagrams
+```
+
+---
+
+## Phase 2: Analyze the Feature
+
+1. **Parse the feature description** from the arguments passed to this command
+2. **Identify the impact zone** — which layers are affected:
+   - Shared types / IPC contracts (`src/shared/`)
+   - Main process services (`src/main/services/`)
+   - IPC handlers (`src/main/ipc/handlers/`)
+   - Renderer features (`src/renderer/features/`)
+   - Router / layouts (`src/renderer/app/`)
+3. **Read existing code** in the impact zone to understand current patterns
+4. **Identify risks** — breaking changes, migration needs, performance concerns
+
+---
+
+## Phase 3: Design the Approach
+
+Produce a plan covering:
+
+### 3a. Data Model
+- New types / interfaces needed
+- Changes to existing types
+- IPC contract additions (channels, schemas)
+
+### 3b. Service Layer
+- New services or modifications to existing ones
+- Sync vs async patterns (local = sync, Hub = async)
+- Error handling approach
+
+### 3c. UI Design
+- New components needed
+- State management approach (Zustand store, React Query hooks)
+- User interaction flow
+
+### 3d. Testing Strategy
+- Unit tests needed (`tests/unit/`)
+- Integration tests needed (`tests/integration/`)
+- Manual verification steps
+
+---
+
+## Phase 4: Task Decomposition
+
+Break the feature into **atomic, agent-ready tasks**. Each task must:
+
+1. Be assignable to exactly ONE specialist agent
+2. Have clear file ownership (no two tasks editing the same file)
+3. Have explicit acceptance criteria
+4. List the exact files to create or modify
+
+Standard dependency chain:
+```
+Types/Schema -> Services -> IPC Handlers -> Hooks/Store -> Components -> Router -> Docs
+```
+
+For each task, specify:
+- **Agent role** (from `.claude/agents/` if available, otherwise describe the skill)
+- **Files** to create or modify
+- **Depends on** — which tasks must complete first
+- **Acceptance criteria** — what "done" looks like
+
+Identify which tasks can run **in parallel** (no shared files).
+
+---
+
+## Phase 5: Write the Plan
+
+Write the complete plan to: `docs/plans/<feature-slug>-plan.md`
+
+The feature slug should be derived from the description: lowercase, hyphens, no special chars.
+Example: "Add user authentication" becomes `docs/plans/add-user-authentication-plan.md`
+
+### Plan File Format
+
+```markdown
+# Plan: <Feature Title>
+
+## Summary
+<2-3 sentence overview>
+
+## Impact Analysis
+<Which layers/modules are affected>
+
+## Data Model Changes
+<Types, interfaces, IPC contracts>
+
+## Service Layer Changes
+<New/modified services>
+
+## UI Changes
+<Components, state, user flow>
+
+## Task Breakdown
+
+### Task 1: <title>
+- **Agent:** <role>
+- **Files:** <list>
+- **Depends on:** none | Task N
+- **Acceptance criteria:**
+  - [ ] Criterion 1
+  - [ ] Criterion 2
+
+### Task 2: <title>
+...
+
+## Wave Plan
+Wave 1: Tasks with no dependencies
+Wave 2: Tasks unblocked by Wave 1
+...
+
+## Testing Strategy
+<Unit, integration, manual steps>
+
+## Risks & Mitigations
+<What could go wrong, how to handle it>
+```
+
+---
+
+## Phase 6: Output
+
+After writing the plan file, output the **absolute file path** as the very last line of your response, prefixed with `PLAN_FILE:`. This allows the orchestrator to detect and read the plan.
+
+Example final line:
+```
+PLAN_FILE:docs/plans/add-user-authentication-plan.md
+```
+
+---
+
+## Important Notes
+
+- Do NOT implement any code. This command only produces a plan.
+- Be thorough but concise. Each section should provide enough detail for an agent to implement without further clarification.
+- Consider the existing codebase patterns. New code should follow established conventions.
+- The plan will be reviewed by a human before execution. Make it clear and actionable.

--- a/.claude/commands/resume-feature.md
+++ b/.claude/commands/resume-feature.md
@@ -1,0 +1,122 @@
+# /resume-feature — Checkpoint Recovery
+
+> Resume a previously interrupted feature implementation from its last checkpoint. Reads progress context, identifies where the previous agent stopped, and continues from that point.
+
+**Usage:** Called by the orchestrator with progress context injected into the prompt.
+
+---
+
+## Phase 1: Understand Context
+
+You have been spawned to resume work that a previous agent started but did not finish.
+
+1. **Read the progress context** provided in your prompt (JSONL entries from the previous session)
+2. **Identify the original task** from the "Original task:" line in your prompt
+3. **Determine the phase** — was the previous agent planning or executing?
+
+---
+
+## Phase 2: Load Project Context
+
+Read these files to understand the system:
+
+```
+MANDATORY READS:
+1. CLAUDE.md                       — Project rules, tech stack, patterns
+2. ai-docs/ARCHITECTURE.md         — System architecture, IPC flow
+3. ai-docs/PATTERNS.md             — Code conventions, component patterns
+```
+
+---
+
+## Phase 3: Analyze Previous Progress
+
+Parse the JSONL entries to understand what happened:
+
+### Tool Use Entries (`type: "tool_use"`)
+- What tools were used? (Read, Write, Edit, Bash, etc.)
+- This tells you what files were being worked on
+
+### Phase Change Entries (`type: "phase_change"`)
+- What phase was the agent in when it stopped?
+- How far through the total phases did it get?
+
+### Agent Stopped Entries (`type: "agent_stopped"`)
+- Why did the agent stop? (completed, error, killed, timeout)
+- This helps determine if work was partially done
+
+### Error Entries (`type: "error"`)
+- Were there errors? What kind?
+- This helps avoid repeating the same mistakes
+
+---
+
+## Phase 4: Assess Current State
+
+Before resuming work:
+
+1. **Check git status** — Are there uncommitted changes from the previous session?
+   ```bash
+   git status
+   git diff --stat
+   ```
+
+2. **Check for partial work** — Look for files that were being edited:
+   ```bash
+   git diff --name-only
+   ```
+
+3. **Run verification** to see current state:
+   ```bash
+   npm run typecheck 2>&1 | tail -20
+   npm run lint 2>&1 | tail -20
+   ```
+
+4. **Determine resume point:**
+   - If the previous agent completed some tasks cleanly, skip those
+   - If work was partially done on a file, review and continue from there
+   - If there were errors, understand the root cause before retrying
+
+---
+
+## Phase 5: Resume Work
+
+Based on your analysis:
+
+### If resuming a planning phase:
+- Check if a plan file was partially written
+- If yes, review and complete it
+- If no, start the planning process fresh using the `/plan-feature` approach
+- Write the plan to `docs/plans/<feature-slug>-plan.md`
+
+### If resuming an execution phase:
+- Identify which tasks from the plan are complete vs incomplete
+- Start working on the first incomplete task
+- Follow the same patterns and conventions as the original agent
+
+### General resume guidelines:
+- Do NOT redo work that was already completed successfully
+- Do NOT revert changes that look correct
+- If you find broken/partial changes, fix them rather than starting over
+- Commit working checkpoints frequently
+
+---
+
+## Phase 6: Verification
+
+Before claiming work is complete, run the full verification suite:
+
+```bash
+npm run lint && npm run typecheck && npm run test && npm run build && npm run check:docs
+```
+
+All five commands must pass. This is mandatory and non-skippable.
+
+---
+
+## Important Notes
+
+- You are continuing someone else's work. Respect their approach unless it was clearly wrong.
+- If the previous agent's approach was fundamentally flawed, explain why and take a different approach.
+- Always check for uncommitted changes before starting — the previous session may have left work in progress.
+- If you cannot determine what the previous agent was doing, treat this as a fresh start but note what you found.

--- a/src/main/bootstrap/service-registry.ts
+++ b/src/main/bootstrap/service-registry.ts
@@ -99,6 +99,7 @@ export interface ServiceRegistryResult {
   briefingService: ReturnType<typeof createBriefingService>;
   hotkeyManager: ReturnType<typeof createHotkeyManager>;
   settingsService: ReturnType<typeof createSettingsService>;
+  hubApiClient: HubApiClient;
   heartbeatIntervalId: ReturnType<typeof setInterval> | null;
   registeredDeviceId: string | null;
 }
@@ -480,6 +481,7 @@ export function createServiceRegistry(
     briefingService,
     hotkeyManager,
     settingsService,
+    hubApiClient,
     heartbeatIntervalId,
     registeredDeviceId,
   };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -131,6 +131,7 @@ function initializeApp(): void {
     watchEvaluator: registry.watchEvaluator,
     webhookRelay: registry.webhookRelay,
     hubConnectionManager: registry.hubConnectionManager,
+    hubApiClient: registry.hubApiClient,
   });
 
   // Register app lifecycle handlers (quit, activate, cleanup)

--- a/src/main/services/agent-orchestrator/types.ts
+++ b/src/main/services/agent-orchestrator/types.ts
@@ -22,6 +22,7 @@ export interface AgentSession {
   progressFile: string;
   logFile: string;
   hooksConfigPath: string;
+  originalSettingsContent: string | null;
   exitCode: number | null;
   projectPath: string;
   command: string;

--- a/src/renderer/features/tasks/api/useAgentMutations.ts
+++ b/src/renderer/features/tasks/api/useAgentMutations.ts
@@ -48,6 +48,26 @@ export function useStartExecution() {
   });
 }
 
+/** Re-plan a task with user feedback on what to change */
+export function useReplanWithFeedback() {
+  const queryClient = useQueryClient();
+  const { onError } = useMutationErrorToast();
+  return useMutation({
+    mutationFn: (input: {
+      taskId: string;
+      projectPath: string;
+      taskDescription: string;
+      feedback: string;
+      previousPlanPath?: string;
+      subProjectPath?: string;
+    }) => ipc('agent.replanWithFeedback', input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+    },
+    onError: onError('re-plan with feedback'),
+  });
+}
+
 /** Kill an active agent session */
 export function useKillAgent() {
   const queryClient = useQueryClient();

--- a/src/renderer/features/tasks/components/cells/ActionsCell.tsx
+++ b/src/renderer/features/tasks/components/cells/ActionsCell.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 
 import {
   Brain,
+  MessageSquare,
   Play,
   RefreshCw,
   RotateCcw,
@@ -33,6 +34,7 @@ interface ActionsCellData {
 interface ActionsCellProps extends CustomCellRendererProps {
   onStartPlanning?: (taskId: string) => void;
   onStartExecution?: (taskId: string) => void;
+  onRequestChanges?: (taskId: string) => void;
   onKillAgent?: (taskId: string) => void;
   onRestartCheckpoint?: (taskId: string) => void;
 }
@@ -110,6 +112,19 @@ export function ActionsCell(props: ActionsCellProps) {
           onClick={handleKillClick}
         >
           <Square className={ICON_SIZE} />
+        </button>
+      ) : null}
+
+      {/* Request changes — available for plan_ready */}
+      {status === 'plan_ready' ? (
+        <button
+          aria-label="Request changes to plan"
+          className={cn(ICON_BUTTON, 'text-warning hover:text-warning')}
+          onClick={(event) => {
+            handleClick(event, props.onRequestChanges);
+          }}
+        >
+          <MessageSquare className={ICON_SIZE} />
         </button>
       ) : null}
 

--- a/src/renderer/features/tasks/components/detail/PlanFeedbackDialog.tsx
+++ b/src/renderer/features/tasks/components/detail/PlanFeedbackDialog.tsx
@@ -1,0 +1,174 @@
+/**
+ * PlanFeedbackDialog — Dialog with textarea for providing feedback when requesting
+ * changes to an agent plan. Used by PlanViewer for the "Request Changes" action.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import { Loader2, MessageSquare } from 'lucide-react';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+interface PlanFeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (feedback: string) => void;
+  loading?: boolean;
+}
+
+export function PlanFeedbackDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  loading = false,
+}: PlanFeedbackDialogProps) {
+  const [feedback, setFeedback] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Escape key closes the dialog
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onOpenChange(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onOpenChange]);
+
+  // Focus textarea when dialog opens and reset feedback
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    if (open) {
+      setFeedback('');
+      // Delay focus to ensure the DOM has rendered
+      timer = setTimeout(() => {
+        textareaRef.current?.focus();
+      }, 0);
+    }
+
+    return () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  function handleClose() {
+    onOpenChange(false);
+  }
+
+  function handleSubmit() {
+    const trimmed = feedback.trim();
+    if (trimmed.length > 0) {
+      onSubmit(trimmed);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        role="button"
+        tabIndex={0}
+        onClick={handleClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') handleClose();
+        }}
+      />
+
+      {/* Modal */}
+      <div className="bg-card border-border relative z-10 w-full max-w-lg rounded-lg border shadow-xl">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-6 pt-6">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-warning/10">
+            <MessageSquare className="text-warning h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-foreground text-lg font-semibold">Request Changes</h2>
+            <p className="text-muted-foreground text-sm">
+              Describe what changes you&apos;d like to see in the plan.
+            </p>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 pt-4 pb-6">
+          <textarea
+            ref={textareaRef}
+            disabled={loading}
+            placeholder="e.g., Add error handling for the API calls, use a different approach for..."
+            rows={5}
+            value={feedback}
+            className={cn(
+              'border-input bg-background text-foreground placeholder:text-muted-foreground w-full rounded-md border px-3 py-2 text-sm',
+              'focus:ring-ring focus:border-ring focus:outline-none focus:ring-1',
+              'resize-none',
+              'disabled:pointer-events-none disabled:opacity-50',
+            )}
+            onChange={(e) => {
+              setFeedback(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+          />
+          <p className="text-muted-foreground mt-1.5 text-xs">
+            Press Ctrl+Enter to submit
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="border-border flex justify-end gap-2 border-t px-6 py-4">
+          <button
+            disabled={loading}
+            className={cn(
+              'text-muted-foreground hover:text-foreground rounded-md px-4 py-2 text-sm',
+              'transition-colors',
+              'disabled:pointer-events-none disabled:opacity-50',
+            )}
+            onClick={handleClose}
+          >
+            Cancel
+          </button>
+          <button
+            disabled={loading || feedback.trim().length === 0}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium',
+              'transition-opacity hover:opacity-90',
+              'disabled:pointer-events-none disabled:opacity-50',
+              'bg-primary text-primary-foreground',
+            )}
+            onClick={handleSubmit}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Submitting...
+              </>
+            ) : (
+              'Submit Feedback'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/tasks/components/detail/PlanViewer.tsx
+++ b/src/renderer/features/tasks/components/detail/PlanViewer.tsx
@@ -1,11 +1,15 @@
 /**
- * PlanViewer — Displays agent plan content with approve/reject actions.
+ * PlanViewer — Displays agent plan content with approve/reject/request-changes actions.
  * Shown in the task detail row when a plan exists (status plan_ready or later).
  */
 
-import { FileText, Play, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { FileText, MessageSquare, Play, X } from 'lucide-react';
 
 import { cn } from '@renderer/shared/lib/utils';
+
+import { PlanFeedbackDialog } from './PlanFeedbackDialog';
 
 interface PlanViewerProps {
   taskId: string;
@@ -13,6 +17,7 @@ interface PlanViewerProps {
   status: string;
   onApproveAndExecute?: (taskId: string) => void;
   onReject?: (taskId: string) => void;
+  onRequestChanges?: (taskId: string, feedback: string) => void;
 }
 
 const ACTION_BUTTON_BASE =
@@ -24,7 +29,10 @@ export function PlanViewer({
   status,
   onApproveAndExecute,
   onReject,
+  onRequestChanges,
 }: PlanViewerProps) {
+  const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false);
+
   if (!planContent) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center">
@@ -35,6 +43,11 @@ export function PlanViewer({
   }
 
   const showActions = status === 'plan_ready';
+
+  function handleFeedbackSubmit(feedback: string) {
+    onRequestChanges?.(taskId, feedback);
+    setFeedbackDialogOpen(false);
+  }
 
   return (
     <div className="flex flex-col gap-3">
@@ -59,6 +72,19 @@ export function PlanViewer({
               Approve & Execute
             </button>
             <button
+              aria-label="Request changes to plan"
+              className={cn(
+                ACTION_BUTTON_BASE,
+                'bg-warning/10 text-warning hover:bg-warning/20',
+              )}
+              onClick={() => {
+                setFeedbackDialogOpen(true);
+              }}
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              Request Changes
+            </button>
+            <button
               aria-label="Reject plan"
               className={cn(
                 ACTION_BUTTON_BASE,
@@ -80,6 +106,12 @@ export function PlanViewer({
           {planContent}
         </pre>
       </div>
+
+      <PlanFeedbackDialog
+        open={feedbackDialogOpen}
+        onOpenChange={setFeedbackDialogOpen}
+        onSubmit={handleFeedbackSubmit}
+      />
     </div>
   );
 }

--- a/src/renderer/features/tasks/components/detail/TaskDetailRow.tsx
+++ b/src/renderer/features/tasks/components/detail/TaskDetailRow.tsx
@@ -16,6 +16,7 @@ interface TaskDetailRowProps {
   task: Task;
   onApproveAndExecute?: (taskId: string) => void;
   onRejectPlan?: (taskId: string) => void;
+  onRequestChanges?: (taskId: string, feedback: string) => void;
   onKillAgent?: (taskId: string) => void;
   onRestartCheckpoint?: (taskId: string) => void;
   onLaunchWorkflow?: (taskId: string) => void;
@@ -28,7 +29,7 @@ function hasPlan(task: Task): boolean {
   return planStatuses.has(hubStatus) || typeof task.metadata?.planContent === 'string';
 }
 
-export function TaskDetailRow({ task, onApproveAndExecute, onRejectPlan, onKillAgent, onRestartCheckpoint, onLaunchWorkflow }: TaskDetailRowProps) {
+export function TaskDetailRow({ task, onApproveAndExecute, onRejectPlan, onRequestChanges, onKillAgent, onRestartCheckpoint, onLaunchWorkflow }: TaskDetailRowProps) {
   const showPlan = hasPlan(task);
   const planContent = (task.metadata?.planContent as string | undefined) ?? null;
 
@@ -47,6 +48,7 @@ export function TaskDetailRow({ task, onApproveAndExecute, onRejectPlan, onKillA
             taskId={task.id}
             onApproveAndExecute={onApproveAndExecute}
             onReject={onRejectPlan}
+            onRequestChanges={onRequestChanges}
           />
         </div>
       ) : null}

--- a/src/renderer/features/tasks/components/grid/TaskDataGrid.tsx
+++ b/src/renderer/features/tasks/components/grid/TaskDataGrid.tsx
@@ -165,10 +165,16 @@ export function TaskDataGrid({ projectId: projectIdProp }: TaskDataGridProps) {
       const taskProjectId = (task as unknown as { projectId?: string }).projectId ?? projectId ?? '';
       const path = resolveProjectPath(taskProjectId);
       if (path.length === 0) return;
+
+      // Pass planRef from task metadata when available (plan_ready → execution)
+      const metadata = task.metadata as Record<string, unknown> | undefined;
+      const planRef = typeof metadata?.planFilePath === 'string' ? metadata.planFilePath : undefined;
+
       startExecution.mutate({
         taskId,
         projectPath: path,
         taskDescription: task.description,
+        planRef,
       });
     },
     [tasks, projectId, resolveProjectPath, startExecution],

--- a/src/shared/ipc/agents/contract.ts
+++ b/src/shared/ipc/agents/contract.ts
@@ -33,6 +33,17 @@ export const orchestratorInvoke = {
     input: z.object({ sessionId: z.string() }),
     output: z.object({ success: z.boolean() }),
   },
+  'agent.replanWithFeedback': {
+    input: z.object({
+      taskId: z.string(),
+      projectPath: z.string(),
+      taskDescription: z.string(),
+      feedback: z.string(),
+      previousPlanPath: z.string().optional(),
+      subProjectPath: z.string().optional(),
+    }),
+    output: z.object({ sessionId: z.string(), status: z.literal('spawned') }),
+  },
   'agent.restartFromCheckpoint': {
     input: z.object({ taskId: z.string(), projectPath: z.string() }),
     output: z.object({ sessionId: z.string(), status: z.literal('spawned') }),

--- a/src/shared/ipc/agents/schemas.ts
+++ b/src/shared/ipc/agents/schemas.ts
@@ -30,6 +30,7 @@ export const OrchestratorSessionSchema = z.object({
   progressFile: z.string(),
   logFile: z.string(),
   hooksConfigPath: z.string(),
+  originalSettingsContent: z.string().nullable(),
   exitCode: z.number().nullable(),
   projectPath: z.string(),
   command: z.string(),


### PR DESCRIPTION
## Summary

- Fix 8 broken links in the task planning pipeline to enable the full end-to-end workflow: **idea → plan → review → approve/reject/request changes → execute**
- Create standalone `/plan-feature` and `/resume-feature` CLI commands that work with a clean Claude CLI install
- Fix hooks config to merge into `.claude/settings.local.json` (was writing to ignored `hooks-{taskId}.json` files)
- Auto-detect plan files when planning agent completes, transition task to `plan_ready` status with plan content in metadata
- Add `PlanFeedbackDialog` component for "Request Changes" action with textarea feedback
- Add `agent.replanWithFeedback` IPC channel that re-spawns planning agent with user feedback context
- Pass `planRef` from task metadata to execution agent on plan approval

## Test plan

- [x] `npm run lint` — zero violations
- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 181 tests pass (105 unit + 76 integration)
- [x] `npm run build` — builds successfully
- [x] `npm run check:docs` — 3 doc files updated for 14 source changes
- [ ] Manual: Create task → Start Planning → verify agent spawns with `/plan-feature`
- [ ] Manual: Verify JSONL progress entries appear (hooks working)
- [ ] Manual: Verify task transitions to `plan_ready` on completion
- [ ] Manual: Verify PlanViewer shows rendered plan content
- [ ] Manual: Click "Request Changes", enter feedback, verify re-plan spawns
- [ ] Manual: Click "Approve & Execute", verify execution agent receives planRef

🤖 Generated with [Claude Code](https://claude.com/claude-code)