### PR TITLE
feat: Medium-term UI gaps — Hub Setup, merge diff, OAuth, voice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,12 @@
 > Desktop UI for managing Claude autonomous coding agents.
 > Electron 39 + React 19 + TypeScript strict + Tailwind v4 + Zustand 5
 
+## Implementation Rule — MANDATORY
+
+**When a plan exists (from `/plan-feature`, `/create-feature-plan`, or user-provided), ALWAYS use the `/implement-feature` skill with parallel agent teams.** Do NOT single-thread implementation yourself. Specialized agents working in parallel are faster and more efficient than sequential solo execution. This applies to ALL planned work — no exceptions, no "this is small enough to do myself" overrides. Use the workflow tooling. That's what it's there for.
+
+---
+
 ## Quick Reference
 
 ```bash

--- a/ai-docs/FEATURES-INDEX.md
+++ b/ai-docs/FEATURES-INDEX.md
@@ -9,7 +9,7 @@
 
 | Category | Count |
 |----------|-------|
-| Renderer Features | 27 |
+| Renderer Features | 28 |
 | Main Process Services | 32 |
 | IPC Handler Files | 41 |
 | IPC Domain Folders | 24 |
@@ -34,6 +34,7 @@ Location: `src/renderer/features/`
 | **dashboard** | Home dashboard | DashboardPage, TodayView, DailyStats, ActiveAgents | multiple |
 | **fitness** | Health/fitness tracking | FitnessPage, WorkoutLog, MetricsChart | `fitness.*` |
 | **github** | GitHub integration | GitHubPage, PRList, IssueList | `github.*` |
+| **hub-setup** | Pre-auth Hub configuration wizard | HubSetupPage, validateHubUrl | `hub.getConfig`, `hub.connect` |
 | **ideation** | Idea capture & tracking | IdeationPage, IdeaEditForm | `ideas.*` |
 | **insights** | Analytics dashboard | InsightsPage, MetricsCards, Charts | `insights.*` |
 | **notes** | Note-taking | NotesPage, NoteEditor, NoteList | `notes.*` |

--- a/src/renderer/app/router.tsx
+++ b/src/renderer/app/router.tsx
@@ -57,7 +57,7 @@ const indexRoute = createRoute({
 
 // ─── Route Groups ────────────────────────────────────────────
 
-const { loginRoute, registerRoute } = createAuthRoutes(rootRoute);
+const { loginRoute, registerRoute, hubSetupRoute } = createAuthRoutes(rootRoute);
 
 const dashboardRoutes = createDashboardRoutes(appLayoutRoute);
 const projectRoutes = createProjectRoutes(appLayoutRoute);
@@ -71,6 +71,7 @@ const miscRoutes = createMiscRoutes(appLayoutRoute);
 const routeTree = rootRoute.addChildren([
   loginRoute,
   registerRoute,
+  hubSetupRoute,
   authLayoutRoute.addChildren([
     appLayoutRoute.addChildren([
       indexRoute,

--- a/src/renderer/features/auth/components/LoginPage.tsx
+++ b/src/renderer/features/auth/components/LoginPage.tsx
@@ -12,11 +12,12 @@ const INPUT_CLASS =
   'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring';
 
 interface LoginPageProps {
+  onNavigateToHubSetup: () => void;
   onNavigateToRegister: () => void;
   onSuccess: () => void;
 }
 
-export function LoginPage({ onNavigateToRegister, onSuccess }: LoginPageProps) {
+export function LoginPage({ onNavigateToHubSetup, onNavigateToRegister, onSuccess }: LoginPageProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const login = useLogin();
@@ -111,6 +112,16 @@ export function LoginPage({ onNavigateToRegister, onSuccess }: LoginPageProps) {
             onClick={onNavigateToRegister}
           >
             Sign up
+          </button>
+        </p>
+
+        <p className="text-center text-sm text-muted-foreground">
+          <button
+            className="font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            type="button"
+            onClick={onNavigateToHubSetup}
+          >
+            Change Hub server
           </button>
         </p>
       </div>

--- a/src/renderer/features/auth/components/RegisterPage.tsx
+++ b/src/renderer/features/auth/components/RegisterPage.tsx
@@ -14,6 +14,7 @@ const INPUT_CLASS =
 const MIN_PASSWORD_LENGTH = 8;
 
 interface RegisterPageProps {
+  onNavigateToHubSetup: () => void;
   onNavigateToLogin: () => void;
   onSuccess: () => void;
 }
@@ -28,7 +29,7 @@ function getPasswordError(password: string, confirmPassword: string): string | n
   return null;
 }
 
-export function RegisterPage({ onNavigateToLogin, onSuccess }: RegisterPageProps) {
+export function RegisterPage({ onNavigateToHubSetup, onNavigateToLogin, onSuccess }: RegisterPageProps) {
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -172,6 +173,16 @@ export function RegisterPage({ onNavigateToLogin, onSuccess }: RegisterPageProps
             onClick={onNavigateToLogin}
           >
             Sign in
+          </button>
+        </p>
+
+        <p className="text-center text-sm text-muted-foreground">
+          <button
+            className="font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            type="button"
+            onClick={onNavigateToHubSetup}
+          >
+            Change Hub server
           </button>
         </p>
       </div>

--- a/src/renderer/features/hub-setup/components/HubSetupPage.tsx
+++ b/src/renderer/features/hub-setup/components/HubSetupPage.tsx
@@ -1,0 +1,210 @@
+/**
+ * HubSetupPage — Pre-auth screen for first-time Hub configuration.
+ *
+ * Shown when no Hub URL is configured. Guides users through Docker setup
+ * and validates connectivity before proceeding to login.
+ */
+
+import { useState } from 'react';
+
+import { ArrowRight, Check, Copy, Loader2, Server, Terminal } from 'lucide-react';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+import { useHubConnect } from '@features/settings/api/useHub';
+
+import { validateHubUrl } from '../lib/validateHubUrl';
+
+const INPUT_CLASS =
+  'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring';
+
+const BUTTON_BASE =
+  'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors';
+
+const DOCKER_COMMAND = 'docker run -d -p 3000:3000 --name adc-hub adchub/adc-hub:latest';
+
+interface HubSetupPageProps {
+  onSuccess: () => void;
+  onNavigateToLogin: () => void;
+}
+
+export function HubSetupPage({ onSuccess, onNavigateToLogin }: HubSetupPageProps) {
+  const [hubUrl, setHubUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const connectMutation = useHubConnect();
+
+  const isFormValid = hubUrl.length > 0 && apiKey.length > 0;
+  const isPending = isValidating || connectMutation.isPending;
+
+  function handleCopy() {
+    void (async () => {
+      await navigator.clipboard.writeText(DOCKER_COMMAND);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    })();
+  }
+
+  async function handleConnect() {
+    if (!isFormValid) return;
+
+    setValidationError(null);
+    setIsValidating(true);
+
+    const validation = await validateHubUrl(hubUrl);
+    setIsValidating(false);
+
+    if (!validation.reachable) {
+      setValidationError(validation.error ?? 'Hub server is unreachable');
+      return;
+    }
+
+    connectMutation.mutate(
+      { url: hubUrl, apiKey },
+      { onSuccess },
+    );
+  }
+
+  function getButtonLabel(): string {
+    if (isValidating) return 'Checking connection...';
+    if (connectMutation.isPending) return 'Connecting...';
+    return 'Connect';
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-lg space-y-6 rounded-lg border border-border bg-card p-8 shadow-lg">
+        {/* Header */}
+        <div className="space-y-2 text-center">
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-lg bg-primary/10">
+            <Server className="size-6 text-primary" />
+          </div>
+          <h1 className="text-2xl font-bold text-card-foreground">Connect to ADC Hub</h1>
+          <p className="text-sm text-muted-foreground">
+            Configure your Hub server to get started
+          </p>
+        </div>
+
+        {/* Docker instructions */}
+        <div className="space-y-2 rounded-md border border-border bg-muted/50 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-card-foreground">
+            <Terminal className="size-4" />
+            Quick Start with Docker
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Run the following command to start a local Hub server:
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 rounded bg-background px-3 py-2 font-mono text-xs text-foreground">
+              {DOCKER_COMMAND}
+            </code>
+            <button
+              aria-label="Copy Docker command"
+              type="button"
+              className={cn(
+                'shrink-0 rounded-md border border-border p-2 text-muted-foreground',
+                'hover:bg-accent hover:text-accent-foreground',
+              )}
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <Check className="size-4 text-success" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Connection form */}
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleConnect();
+          }}
+        >
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-card-foreground" htmlFor="setup-hub-url">
+              Hub URL
+            </label>
+            <input
+              autoComplete="url"
+              className={INPUT_CLASS}
+              id="setup-hub-url"
+              placeholder="http://localhost:3000"
+              type="url"
+              value={hubUrl}
+              onChange={(e) => { setHubUrl(e.target.value); }}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-card-foreground" htmlFor="setup-api-key">
+              API Key
+            </label>
+            <input
+              autoComplete="off"
+              className={INPUT_CLASS}
+              id="setup-api-key"
+              placeholder="Enter your Hub API key"
+              type="password"
+              value={apiKey}
+              onChange={(e) => { setApiKey(e.target.value); }}
+            />
+          </div>
+
+          {/* Errors */}
+          {validationError === null ? null : (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              Hub unreachable: {validationError}
+            </div>
+          )}
+
+          {connectMutation.isError && validationError === null ? (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {connectMutation.error instanceof Error
+                ? connectMutation.error.message
+                : 'Connection failed. Check your URL and API key.'}
+            </div>
+          ) : null}
+
+          <button
+            disabled={!isFormValid || isPending}
+            type="submit"
+            className={cn(
+              BUTTON_BASE,
+              'w-full bg-primary text-primary-foreground',
+              'hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+            )}
+          >
+            {isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ArrowRight className="size-4" />
+            )}
+            {getButtonLabel()}
+          </button>
+        </form>
+
+        {/* Footer link */}
+        <p className="text-center text-sm text-muted-foreground">
+          Already connected?{' '}
+          <button
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            type="button"
+            onClick={onNavigateToLogin}
+          >
+            Sign in
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/hub-setup/index.ts
+++ b/src/renderer/features/hub-setup/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Hub Setup feature — public API
+ */
+
+export { HubSetupPage } from './components/HubSetupPage';
+export { validateHubUrl } from './lib/validateHubUrl';

--- a/src/renderer/features/hub-setup/lib/validateHubUrl.ts
+++ b/src/renderer/features/hub-setup/lib/validateHubUrl.ts
@@ -1,0 +1,36 @@
+/**
+ * Validate a Hub URL by pinging its health endpoint.
+ *
+ * Shared between HubSetupPage (pre-auth) and HubSettings (in-app).
+ */
+
+export async function validateHubUrl(url: string): Promise<{ reachable: boolean; error?: string }> {
+  const trimmedUrl = url.replace(/\/+$/, '');
+  const healthUrl = `${trimmedUrl}/api/health`;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, 5000);
+
+    const response = await fetch(healthUrl, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return { reachable: false, error: `Server returned ${String(response.status)}` };
+    }
+
+    return { reachable: true };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { reachable: false, error: 'Connection timed out' };
+    }
+    const message = error instanceof Error ? error.message : 'Network error';
+    return { reachable: false, error: message };
+  }
+}

--- a/src/renderer/features/settings/components/HubSettings.tsx
+++ b/src/renderer/features/settings/components/HubSettings.tsx
@@ -11,6 +11,8 @@ import { Cloud, CloudOff, Loader2, RefreshCw, Trash2 } from 'lucide-react';
 
 import { cn } from '@renderer/shared/lib/utils';
 
+import { validateHubUrl } from '@features/hub-setup/lib/validateHubUrl';
+
 import {
   useHubConnect,
   useHubDisconnect,
@@ -40,38 +42,6 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 // ── Sub-components ──────────────────────────────────────────
-
-/** Ping hub health endpoint to validate URL before saving. */
-async function validateHubUrl(url: string): Promise<{ reachable: boolean; error?: string }> {
-  const trimmedUrl = url.replace(/\/+$/, '');
-  const healthUrl = `${trimmedUrl}/api/health`;
-
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-    }, 5000);
-
-    const response = await fetch(healthUrl, {
-      method: 'GET',
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      return { reachable: false, error: `Server returned ${String(response.status)}` };
-    }
-
-    return { reachable: true };
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return { reachable: false, error: 'Connection timed out' };
-    }
-    const message = error instanceof Error ? error.message : 'Network error';
-    return { reachable: false, error: message };
-  }
-}
 
 interface ConnectionFormProps {
   isConnecting: boolean;

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   INDEX: '/',
   LOGIN: '/login',
   REGISTER: '/register',
+  HUB_SETUP: '/hub-setup',
   ALERTS: '/alerts',
   ASSISTANT: '/assistant',
   BRIEFING: '/briefing',


### PR DESCRIPTION
## Summary

- **Hub Setup Wizard** (`/hub-setup`): Pre-auth screen that breaks the Hub config chicken-and-egg problem. First-time users are redirected here before login when no Hub URL is configured. Includes Docker quick-start instructions, URL/API key form, and health endpoint validation. Login and Register pages now have a "Change Hub server" link.
- **Merge Diff Viewer**: Enhanced `MergePreviewPanel` with `FileDiffViewer` using `@git-diff-view/react`, `ConflictResolver` for interactive merge conflict resolution, and `MergeConfirmModal` upgrade.
- **OAuth Flow**: New `oauth.*` IPC channels (`oauth.authorize`, `oauth.isAuthenticated`, `oauth.revoke`), `OAuthConnectionStatus` component for per-provider connect/disconnect in Settings.
- **VoiceButton**: Voice interface UI with `VoiceSettings` mounted in Settings page.
- **Misc**: Briefing route added to sidebar, `CommandBar` wired in `TopBar`, shared `validateHubUrl` extracted from `HubSettings`.

## Files changed (42 files, +1847 / -195)

### New features
- `src/renderer/features/hub-setup/` — HubSetupPage, validateHubUrl, barrel
- `src/renderer/features/merge/components/FileDiffViewer.tsx` — Git diff viewer
- `src/shared/ipc/oauth/` — OAuth IPC contract, schemas, barrel
- `src/renderer/features/settings/api/useOAuth.ts` — OAuth React Query hooks
- `src/renderer/features/settings/components/OAuthConnectionStatus.tsx` — OAuth UI

### Modified
- `src/renderer/app/routes/auth.routes.tsx` — Async hub config guards + `/hub-setup` route
- `src/renderer/features/auth/components/LoginPage.tsx` / `RegisterPage.tsx` — Hub setup link
- `src/renderer/features/merge/` — ConflictResolver, MergePreviewPanel, MergeConfirmModal upgrades
- `src/renderer/features/settings/components/HubSettings.tsx` — Shared validateHubUrl import
- `CLAUDE.md` — Added mandatory rule for planned work to use /implement-feature

## Test plan

- [ ] Fresh state (no `hub-config.json`) → app redirects to `/hub-setup`
- [ ] Navigate to `/login` directly → redirects to `/hub-setup`
- [ ] Enter Hub URL + key → Connect → success → redirects to `/login`
- [ ] Hub already configured → `/hub-setup` redirects to `/login`
- [ ] "Change Hub server" link on login/register → navigates to `/hub-setup`
- [ ] Invalid Hub URL → validation error, no redirect
- [ ] OAuth connect/disconnect flows in Settings
- [ ] Merge diff viewer renders file diffs correctly
- [ ] All verification passes: lint, typecheck, 181 tests, build, check:docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)