### PR TITLE
chore: add feature plans and update tracker

### DIFF
--- a/docs/features/command-palette/plan.md
+++ b/docs/features/command-palette/plan.md
@@ -1,0 +1,62 @@
+# Global Command Palette
+
+> Tracker Key: `command-palette` | Status: **DRAFT** | Priority: **P1** | Created: 2026-02-26
+
+---
+
+## Problem
+
+Navigation relies entirely on the sidebar. No way to quickly jump to a feature, project, task, or action without clicking through menus. Power users need keyboard-driven navigation.
+
+## Goals
+
+- `Cmd+K` / `Ctrl+K` opens a fuzzy-search command palette
+- Search across: routes/pages, projects, tasks, recent items, actions
+- Keyboard-driven: arrow keys to navigate, Enter to select, Esc to close
+- Extensible: features can register their own commands
+
+## Approach
+
+### Component: `CommandPalette.tsx`
+
+- Dialog overlay with search input + scrollable results list
+- Grouped results: Navigation, Projects, Tasks, Actions
+- Fuzzy matching (use `fuse.js` or similar lightweight fuzzy library)
+- Recent items shown when input is empty
+- Mounted at app root level (inside `LayoutWrapper` or `AppProviders`)
+
+### Registry Pattern
+
+```typescript
+// Features register commands
+commandRegistry.register({
+  id: 'nav.dashboard',
+  label: 'Go to Dashboard',
+  group: 'Navigation',
+  keywords: ['home', 'overview'],
+  action: () => navigate({ to: '/dashboard' }),
+});
+```
+
+- Static nav commands registered at mount
+- Dynamic commands (projects, tasks) loaded on palette open via IPC
+- Actions: theme toggle, sidebar toggle, settings sections
+
+### Keyboard Handling
+
+- Global `Ctrl+K` / `Cmd+K` listener (registered in app root)
+- Arrow Up/Down to navigate results
+- Enter to execute selected command
+- Esc to close
+- Type-ahead filtering with debounce
+
+## Files
+
+- `src/renderer/shared/components/CommandPalette.tsx` — Main component
+- `src/renderer/shared/lib/command-registry.ts` — Registry + types
+- `src/renderer/shared/hooks/useCommandPalette.ts` — Open/close state + keyboard handler
+- Feature modules register commands in their barrel exports or route loaders
+
+## Estimated Effort
+
+~2 days

--- a/docs/features/devices-ui/plan.md
+++ b/docs/features/devices-ui/plan.md
@@ -1,0 +1,45 @@
+# Devices Management Page
+
+> Tracker Key: `devices-ui` | Status: **DRAFT** | Priority: **P1** | Created: 2026-02-26
+
+---
+
+## Problem
+
+Device registration, heartbeat, and management are fully functional in the backend (IPC channels, Hub API proxy, service). But there's no dedicated devices page — device selection is buried in the settings sidebar layout selector.
+
+## Goals
+
+- Dedicated `/devices` page accessible from navigation
+- List registered devices with status, last heartbeat, OS info
+- Register new devices
+- Remove/deregister devices
+- Show which device is currently active
+- Device health indicators (online/offline/stale)
+
+## Approach
+
+### Route
+
+- Add `/devices` route (personal navigation section or settings sub-route)
+- Add to `shared-nav.ts`
+
+### Components
+
+| Component | Purpose |
+|-----------|---------|
+| `DeviceList.tsx` | Table/card list of all registered devices |
+| `DeviceCard.tsx` | Device card with name, OS, status, last seen |
+| `RegisterDeviceDialog.tsx` | Form to register a new device |
+| `DeviceStatusBadge.tsx` | Online/offline/stale indicator |
+
+### Data Flow
+
+Uses existing hooks in `src/renderer/features/devices/`:
+- `useDevices()` — list query
+- `useRegisterDevice()` — mutation
+- `useDeviceEvents()` — WebSocket event handler for status changes
+
+## Estimated Effort
+
+~1 day (backend complete, just UI components needed)

--- a/docs/features/docs-sync/plan.md
+++ b/docs/features/docs-sync/plan.md
@@ -1,0 +1,63 @@
+# Documentation Sync Pass
+
+> Tracker Key: `docs-sync` | Status: **DRAFT** | Priority: **P0** | Created: 2026-02-26
+
+---
+
+## Problem
+
+The `ai-docs/` directory has fallen behind the actual codebase. An audit found **47 discrepancies** across service counts, feature listings, handler documentation, IPC domains, and patterns.
+
+## Scope
+
+### FEATURES-INDEX.md — Stale Counts & Missing Entries
+
+| Item | Documented | Actual | Delta |
+|------|-----------|--------|-------|
+| Renderer Features | 29 | 31 | +2 missing (communications, workflow-pipeline) |
+| Main Services | 33 | 35 | +2 missing |
+| IPC Domains | 27 | 30 | +3 missing (docker, agents, +1) |
+| Handler Files | 42 | ~48 | +6 missing (dashboard, docker, error, hotkey, mcp, tracker, window) |
+
+**Missing services from table:** app, calendar, docker, health, ideas, insights, screen, terminal, time-parser, tracker, workflow (11 total)
+
+**Missing features from table:** communications, health, workflow-pipeline (3 undocumented + 8 with minimal docs)
+
+### PATTERNS.md — Stale Sidebar Guidance
+
+- "Adding a New Feature" section still says "add nav item to Sidebar.tsx"
+- Should reference `shared-nav.ts` + the 16-layout system
+- No mention of `LayoutWrapper.tsx` or `LAYOUT_MAP`
+
+### ARCHITECTURE.md — Stale Counts & References
+
+- Lists 32 services (actual: 35)
+- Agent system references `AgentService` but primary is `agent-orchestrator`
+- Terminal service path incorrect
+
+### Agent Definitions (`.claude/agents/*.md`)
+
+- Need audit against actual codebase for stale references
+- New features (communications, health, workflow-pipeline) not reflected
+- Sidebar layout changes need propagation to all UI-facing agents
+
+## Tasks
+
+1. **Update FEATURES-INDEX.md** — Add all missing services, features, handlers, IPC domains; fix counts
+2. **Update PATTERNS.md** — Fix "Adding a Feature" section for new sidebar system; update primitive counts
+3. **Update ARCHITECTURE.md** — Fix service count, agent system references, terminal path
+4. **Audit agent definitions** — Check all `.claude/agents/*.md` files for stale references
+5. **Update DATA-FLOW.md** — Add any missing data flows for new services
+6. **Verify with `npm run check:docs`** — Ensure doc check passes
+
+## Verification
+
+- `npm run check:docs` passes
+- All service/feature/handler counts in docs match reality
+- No references to files that don't exist
+- PATTERNS.md sidebar guidance matches current implementation
+- Agent definitions reference current file paths and patterns
+
+## Estimated Effort
+
+~2 days with parallel agents (can split by doc file)

--- a/docs/features/future-roadmap/plan.md
+++ b/docs/features/future-roadmap/plan.md
@@ -1,58 +1,64 @@
-# Future Roadmap — Deferred Items from Hardening Brainstorm
+# Future Roadmap
 
-> Tracker Key: `future-roadmap` | Status: **TRACKING** | Created: 2026-02-16
+> Tracker Key: `future-roadmap` | Status: **TRACKING** | Created: 2026-02-16 | Updated: 2026-02-26
 
 ---
 
-## From Hardening Brainstorm
+## Prioritized Roadmap
 
-### Layout Uplevel — Personal & Workspaces with Breadcrumbs (Major Feature)
+All items below are tracked individually in `docs/tracker.json`. Items marked with a slug link to their plan file in `docs/features/<slug>/plan.md`.
 
-Top-level navigation restructure that introduces **Personal** and **Workspaces** as distinct areas with breadcrumb navigation:
+### P0 — Fix Now (Blocking Quality)
 
-- **Workspaces:** Projects, tasks, agents, terminals, GitHub, workflow — the existing work features grouped under workspace context with breadcrumb trails (Workspace > Project > Tasks)
-- **Personal:** Calendar, fitness, todos, journal, weekly planner — personal features with their own dashboard and breadcrumb trails (Personal > Planner > Weekly Review)
-- **Breadcrumb system:** Persistent breadcrumb bar below the title bar showing the user's current location in the hierarchy, with clickable segments for navigation
-- **Personal dashboard:** Customizable widget grid (week/day schedule planner view):
-  - Fitness tracker widget
-  - Calendar widget (small + full planner view)
-  - Google Calendar integration with multi-email account support (personal + work calendars)
-  - Add, edit, RSVP for events populated via Google Calendar and other services
-  - Error notification header for personal feature errors
-- **No code separation** — this is a UX/UI distinction between feature categories, not a codebase restructure. Features remain in `features/` as-is, the layout/routing layer groups them.
-- **Personal error handling:** Left sidebar (for now), tied into the unified toast + assistant system
-- **Update VISION.md** to reflect this layout structure
+| Slug | Title | Type | Effort | Plan |
+|------|-------|------|--------|------|
+| `sidebar-architecture-refactor` | Sidebar/Navigation Architecture Refactor | Refactor | ~3 days | [plan](../sidebar-architecture-refactor/plan.md) |
+| `docs-sync` | Documentation Sync Pass | Docs | ~2 days | [plan](../docs-sync/plan.md) |
 
-### GitHub CI/CD Pipeline
+**Why P0:** The sidebar has 2,491 lines of 95% duplicated code across 16 files. Any nav change touches all 16. The docs have 47 stale items that will cause agents to produce incorrect code.
 
-GitHub Actions workflow design:
-- Run on push and PR
-- Jobs: lint, typecheck, test (unit + integration), build, E2E
-- Electron + Playwright E2E in CI (headless)
-- Coverage reporting with minimum thresholds
-- Caching for node_modules and Electron binaries
-- PR status checks (required passing before merge)
+### P1 — High Impact Features
 
-### Tier 2 Tests
+| Slug | Title | Type | Effort | Plan |
+|------|-------|------|--------|------|
+| `command-palette` | Global Command Palette | Feature | ~2 days | [plan](../command-palette/plan.md) |
+| `workspace-ui` | Workspaces Management UI | Feature | ~1 day | [plan](../workspace-ui/plan.md) |
+| `devices-ui` | Devices Management Page | Feature | ~1 day | [plan](../devices-ui/plan.md) |
+| `productivity-hub-restructure` | Productivity Hub Restructure | Refactor | ~2 days | [plan](../productivity-hub-restructure/plan.md) |
 
-- IPC handler response shape tests for all 38 handler files
-- Hub API client request/response tests
-- Agent orchestrator session lifecycle tests
-- Service health registry edge cases
+**Why P1:** Workspaces and devices backends are fully wired with zero UI. Command palette transforms navigation UX. Productivity hub is cramped with 5 features in tabs.
 
-### Tier 3 Tests
+### P2 — Medium Impact
 
-- Component rendering tests (React Testing Library)
-- Full E2E feature flows:
-  - Create project → add tasks → run agent → view results
-  - Settings persistence across restart
-  - Error boundary recovery flows
-- Coverage reporting integration
+| Slug | Title | Type | Effort |
+|------|-------|------|--------|
+| `favorites-pinning` | Favorites & Pinning System | Feature | ~2 days |
+| `task-bulk-ops` | Bulk Task Operations | Feature | ~2 days |
+| `agent-dashboard-enhanced` | Enhanced Agent Dashboard | Feature | ~2 days |
+| `insights-analytics` | Insights Analytics Upgrade | Feature | ~3 days |
+| `health-dashboard` | Service Health Dashboard | Feature | ~1 day |
 
-### Additional Hardening (Lower Priority)
+### P3 — Polish & Infrastructure
 
-- **Database migration system** — if JSON stores evolve, need versioned migrations
-- **Offline mode resilience** — graceful degradation when Hub is unreachable
-- **Memory leak detection** — long-running app monitoring
-- **Startup performance** — profiling and optimization for cold start
-- **Accessibility audit** — full a11y pass beyond what jsx-a11y catches
+| Slug | Title | Type | Effort |
+|------|-------|------|--------|
+| `ci-cd-pipeline` | GitHub Actions CI/CD Pipeline | Infra | ~1 day |
+| `e2e-test-expansion` | E2E Test Suite Expansion | Tests | ~3 days |
+| `accessibility-audit` | WCAG Accessibility Audit | Quality | ~2 days |
+| `offline-resilience` | Offline Mode / Graceful Degradation | Feature | ~3 days |
+| `eslint-warnings-cleanup` | Clean ESLint Warnings | Cleanup | ~1 hr |
+
+---
+
+## Archived — Previously Tracked (Now Separate Entries)
+
+The following items from the original hardening brainstorm are now tracked as individual entries:
+
+- **Layout Uplevel** → Superseded by `sidebar-architecture-refactor` + `productivity-hub-restructure`
+- **GitHub CI/CD Pipeline** → Tracked as `ci-cd-pipeline`
+- **Tier 2-3 Tests** → Tracked as `e2e-test-expansion`
+- **Database migration system** → Deferred (no immediate need)
+- **Offline mode resilience** → Tracked as `offline-resilience`
+- **Memory leak detection** → Deferred (not yet a reported issue)
+- **Startup performance** → Deferred (not yet a reported issue)
+- **Accessibility audit** → Tracked as `accessibility-audit`

--- a/docs/features/productivity-hub-restructure/plan.md
+++ b/docs/features/productivity-hub-restructure/plan.md
@@ -1,0 +1,57 @@
+# Productivity Hub Restructure
+
+> Tracker Key: `productivity-hub-restructure` | Status: **DRAFT** | Priority: **P1** | Created: 2026-02-26
+
+---
+
+## Problem
+
+Five features (Notes, Planner, Briefing, Alerts, Communications) are crammed into a single tabbed view under the "Productivity" route. The tab layout is cramped, features fight for space, and users can't keep multiple productivity views open simultaneously.
+
+## Goals
+
+- Break productivity features into proper sub-routes or a flexible layout
+- Each feature gets adequate screen real estate
+- Users can navigate directly to any productivity feature via sidebar or command palette
+- Maintain the "Productivity" grouping for organization but not as a tab container
+
+## Options
+
+### Option A: Sub-routes (Recommended)
+
+Replace the tab view with sub-routes:
+- `/productivity` — Overview/dashboard with widget cards for each feature
+- `/productivity/planner` — Full planner view
+- `/productivity/notes` — Full notes view
+- `/productivity/briefing` — Full briefing view
+- `/productivity/alerts` — Full alerts view
+- `/productivity/communications` — Full communications view
+
+Sidebar shows "Productivity" as a collapsible group with each feature as a child item.
+
+### Option B: Resizable Grid Layout
+
+Keep single page but use `react-resizable-panels` to let users arrange features in a customizable grid. More complex but allows multi-feature views.
+
+## Approach (Option A)
+
+1. Create route group for `/productivity/*` with sub-routes
+2. Create `ProductivityDashboard.tsx` overview page with summary cards
+3. Move each tab content into its own route component
+4. Update `shared-nav.ts` to show Productivity as expandable group
+5. Update breadcrumbs to show `Productivity > Planner` etc.
+6. Remove the tab container component
+
+## Files Touched
+
+- `src/renderer/app/routes/` — New productivity route group
+- `src/renderer/features/planner/` — Standalone route wrapper
+- `src/renderer/features/notes/` — Standalone route wrapper
+- `src/renderer/features/briefing/` — Standalone route wrapper
+- `src/renderer/features/alerts/` — Standalone route wrapper
+- `src/renderer/features/communications/` — Standalone route wrapper
+- `src/renderer/features/sidebar-layouts/shared-nav.ts` — Expandable productivity group
+
+## Estimated Effort
+
+~2 days

--- a/docs/features/sidebar-architecture-refactor/plan.md
+++ b/docs/features/sidebar-architecture-refactor/plan.md
@@ -1,0 +1,86 @@
+# Sidebar/Navigation Architecture Refactor
+
+> Tracker Key: `sidebar-architecture-refactor` | Status: **DRAFT** | Priority: **P0** | Created: 2026-02-26
+
+---
+
+## Problem
+
+The 16 `SidebarLayoutXX.tsx` files contain ~2,491 lines with ~95% duplicated boilerplate. Adding a nav item, fixing a bug, or changing the header requires touching all 16 files. No shared hooks or layout primitives exist.
+
+### Specific Issues
+
+1. **URL-to-store sync** — Same 6-line regex block copy-pasted 16 times
+2. **Active state detection** — `isPersonalActive`/`isDevActive` helpers duplicated in every file
+3. **Navigation handlers** — `handlePersonalNav`/`handleDevNav` identical across layouts
+4. **Footer** — UserMenu + HubConnectionIndicator + Settings button repeated in all layouts
+5. **Header** — Inconsistent styling (`text-lg font-bold` vs `text-sm font-semibold` vs `text-xl font-bold`)
+6. **No error boundary** in `LayoutWrapper` — if a layout throws, app crashes
+7. **No responsive behavior** — all layouts desktop-only, no breakpoint handling
+8. **Preview SVGs brittle** — manually maintained config objects can go stale
+
+## Goals
+
+- Reduce each layout file from ~180 lines to ~30-40 lines of layout-specific JSX
+- Centralize all shared navigation logic into reusable hooks
+- Create shared layout primitives for footer, header, and collapsible groups
+- Add error boundary to `LayoutWrapper`
+- Normalize header styling across all layouts
+- No user-facing behavior changes (pure refactor)
+
+## Approach
+
+### Phase 1: Extract Shared Hooks
+
+Create these hooks in `src/renderer/shared/hooks/`:
+
+| Hook | Replaces |
+|------|----------|
+| `useUrlProjectSync()` | 6-line URL regex block in every layout |
+| `useSidebarNavigation()` | `handlePersonalNav`, `handleDevNav`, `isPersonalActive`, `isDevActive` |
+| `useActiveRoute()` | Route matching logic scattered across layouts |
+
+### Phase 2: Create Shared Layout Primitives
+
+Create these in `src/renderer/shared/components/layout/`:
+
+| Component | Replaces |
+|-----------|----------|
+| `SidebarHeaderTemplate` | Header section with consistent styling + logo |
+| `SidebarFooterTemplate` | UserMenu + HubConnectionIndicator + Settings |
+| `SidebarNavGroup` | Repeating SidebarGroup + SidebarMenu + SidebarMenuItem pattern |
+| `CollapsibleNavGroup` | Collapsible wrapper used by layouts 02, 05, 09, 11 |
+
+### Phase 3: Refactor Layout Files
+
+Rewrite each `SidebarLayoutXX.tsx` to use the shared hooks and primitives. Each file should only contain layout-specific structure (e.g., collapsible vs flat, dual sidebar, sticky header).
+
+### Phase 4: Add Safety & Polish
+
+- Add `ErrorBoundary` in `LayoutWrapper` around lazy-loaded layouts
+- Add fallback layout if selected layout fails to load
+- Normalize any remaining styling inconsistencies
+- Validate all 16 layouts render correctly post-refactor
+
+## Files Touched
+
+- `src/renderer/features/sidebar-layouts/SidebarLayout01-16.tsx` (all 16)
+- `src/renderer/features/sidebar-layouts/shared-nav.ts` (may reorganize)
+- `src/renderer/shared/hooks/` (3 new hooks)
+- `src/renderer/shared/components/layout/` (4 new primitives)
+- `src/renderer/app/LayoutWrapper.tsx` (add error boundary)
+
+## Verification
+
+- All 16 layouts render identically to pre-refactor (visual regression)
+- `npm run lint && npm run typecheck && npm run test && npm run build && npm run test:e2e`
+- No new ESLint violations
+- Layout switching works in Settings > Display
+- Sidebar collapse/expand works in all layouts
+- Navigation works for all personal + development items
+- Project tab bar still works
+- Breadcrumbs still render correctly
+
+## Estimated Effort
+
+~3 days with parallel agents (4 phases, phases 1-2 can parallelize)

--- a/docs/features/workspace-ui/plan.md
+++ b/docs/features/workspace-ui/plan.md
@@ -1,0 +1,48 @@
+# Workspaces Management UI
+
+> Tracker Key: `workspace-ui` | Status: **DRAFT** | Priority: **P1** | Created: 2026-02-26
+
+---
+
+## Problem
+
+Workspace backend is fully wired (IPC channels `workspace.*`, Hub API proxy, Zustand store, React Query hooks) but has **zero UI components**. Users can't see, create, or manage workspaces.
+
+## Goals
+
+- Dedicated workspaces page accessible from sidebar navigation
+- List workspaces with name, member count, project count
+- Create, edit, rename, delete workspaces
+- View workspace members and projects
+- Switch active workspace context
+
+## Approach
+
+### Route
+
+- Add `/workspaces` route under personal navigation section
+- Add to `shared-nav.ts` personal items
+
+### Components
+
+| Component | Purpose |
+|-----------|---------|
+| `WorkspaceList.tsx` | Card grid or table listing all workspaces |
+| `WorkspaceCard.tsx` | Individual workspace card with name, stats, actions |
+| `CreateWorkspaceDialog.tsx` | Modal form for creating a new workspace |
+| `EditWorkspaceDialog.tsx` | Modal form for editing workspace details |
+| `WorkspaceDetail.tsx` | Detail view showing members + projects |
+
+### Data Flow
+
+Uses existing hooks in `src/renderer/features/workspaces/`:
+- `useWorkspaces()` — list query
+- `useCreateWorkspace()` — mutation
+- `useUpdateWorkspace()` — mutation
+- `useDeleteWorkspace()` — mutation
+
+All IPC channels already wired in `src/shared/ipc/hub/`.
+
+## Estimated Effort
+
+~1 day (backend complete, just UI components needed)

--- a/docs/tracker.json
+++ b/docs/tracker.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "lastUpdated": "2026-02-22",
+  "lastUpdated": "2026-02-26",
   "plans": {
     "future-roadmap": {
       "title": "Future Roadmap",
@@ -71,6 +71,166 @@
       "branch": null,
       "pr": 65,
       "tags": ["ui", "sidebar", "layouts", "shadcn", "breadcrumbs"]
+    },
+    "sidebar-architecture-refactor": {
+      "title": "Sidebar/Navigation Architecture Refactor",
+      "status": "DRAFT",
+      "planFile": "docs/features/sidebar-architecture-refactor/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["refactor", "sidebar", "navigation", "P0"]
+    },
+    "docs-sync": {
+      "title": "Documentation Sync Pass",
+      "status": "DRAFT",
+      "planFile": "docs/features/docs-sync/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["docs", "maintenance", "P0"]
+    },
+    "command-palette": {
+      "title": "Global Command Palette",
+      "status": "DRAFT",
+      "planFile": "docs/features/command-palette/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "ux", "navigation", "P1"]
+    },
+    "workspace-ui": {
+      "title": "Workspaces Management UI",
+      "status": "DRAFT",
+      "planFile": "docs/features/workspace-ui/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "ui", "workspaces", "P1"]
+    },
+    "devices-ui": {
+      "title": "Devices Management Page",
+      "status": "DRAFT",
+      "planFile": "docs/features/devices-ui/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "ui", "devices", "P1"]
+    },
+    "productivity-hub-restructure": {
+      "title": "Productivity Hub Restructure",
+      "status": "DRAFT",
+      "planFile": "docs/features/productivity-hub-restructure/plan.md",
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["refactor", "ui", "productivity", "P1"]
+    },
+    "favorites-pinning": {
+      "title": "Favorites & Pinning System",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "ux", "P2"]
+    },
+    "task-bulk-ops": {
+      "title": "Bulk Task Operations",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "tasks", "ag-grid", "P2"]
+    },
+    "agent-dashboard-enhanced": {
+      "title": "Enhanced Agent Dashboard",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "agents", "monitoring", "P2"]
+    },
+    "insights-analytics": {
+      "title": "Insights Analytics Upgrade",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "analytics", "charts", "P2"]
+    },
+    "health-dashboard": {
+      "title": "Service Health Dashboard",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "monitoring", "health", "P2"]
+    },
+    "ci-cd-pipeline": {
+      "title": "GitHub Actions CI/CD Pipeline",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["infra", "ci-cd", "github-actions", "P3"]
+    },
+    "e2e-test-expansion": {
+      "title": "E2E Test Suite Expansion",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["testing", "e2e", "coverage", "P3"]
+    },
+    "accessibility-audit": {
+      "title": "WCAG Accessibility Audit",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["quality", "accessibility", "a11y", "P3"]
+    },
+    "offline-resilience": {
+      "title": "Offline Mode / Graceful Degradation",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["feature", "resilience", "offline", "P3"]
+    },
+    "eslint-warnings-cleanup": {
+      "title": "Clean ESLint Warnings",
+      "status": "DRAFT",
+      "planFile": null,
+      "created": "2026-02-26",
+      "statusChangedAt": "2026-02-26",
+      "branch": null,
+      "pr": null,
+      "tags": ["cleanup", "lint", "P3"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds plan docs for 6 upcoming features: command-palette, devices-ui, docs-sync, productivity-hub-restructure, sidebar-architecture-refactor, workspace-ui
- Updates `docs/tracker.json` with all new entries
- Refreshes future-roadmap plan

## Test plan
- [x] `npm run validate:tracker` passes
- [ ] Review plan docs for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)