### PR TITLE
feat: visualization canvas — codebase graph + agent teams viewer

### DIFF
--- a/.claude/.workflow-state/wave-1-spawned.json
+++ b/.claude/.workflow-state/wave-1-spawned.json
@@ -1,11 +1,17 @@
 {
   "wave": 1,
   "tasks": [
-    "task-1"
+    "task-1",
+    "task-2",
+    "task-3"
   ],
   "agentIds": {
-    "coder-task-1": "coder-task-1@tmux-replacement",
-    "qa-task-1": "qa-task-1@tmux-replacement"
+    "coder-task-1": "coder-task-1@visualization-canvas",
+    "qa-task-1": "qa-task-1@visualization-canvas",
+    "coder-task-2": "coder-task-2@visualization-canvas",
+    "qa-task-2": "qa-task-2@visualization-canvas",
+    "coder-task-3": "coder-task-3@visualization-canvas",
+    "qa-task-3": "qa-task-3@visualization-canvas"
   },
-  "spawnedAt": "2026-04-04T01:33:05.160Z"
+  "spawnedAt": "2026-04-04T19:55:44.807Z"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ logs/security/
 .claude/teams/
 .claude/tasks/
 .claude/settings.json
+.claude/settings.local.json
 .playwright-mcp/
 
 # Logs

--- a/src/main/services/visualization/agent-teams.ts
+++ b/src/main/services/visualization/agent-teams.ts
@@ -1,0 +1,423 @@
+/**
+ * Agent Teams Reader
+ *
+ * Reads .claude/tracking/ and .claude/progress/ directories from a project
+ * to build structured agent team data for visualization.
+ */
+
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type {
+  AgentStatus,
+  AgentTaskInfo,
+  AgentTeamsData,
+  FeatureAgentData,
+  TrackingEvent,
+} from './types';
+
+// ─── Agent Name Helpers ───────────────────────────────────────
+
+export function agentNameToTaskNumber(name: string): number | null {
+  const m = /task-(\d+)/.exec(name);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// ─── File Scope Extraction ────────────────────────────────────
+
+export function extractFileScope(content: string): string[] {
+  const filePaths: string[] = [];
+  for (const section of ['## Files to Modify', '## Files to Create']) {
+    const idx = content.indexOf(section);
+    if (idx === -1) continue;
+    const afterSection = content.slice(idx + section.length);
+    const nextSection = afterSection.search(/^## /m);
+    const sectionContent = nextSection === -1 ? afterSection : afterSection.slice(0, nextSection);
+    for (const line of sectionContent.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('- ')) continue;
+      const pathPart = trimmed.slice(2).split(' —')[0].split(' --')[0].trim();
+      if (pathPart.length > 0 && pathPart.includes('.')) filePaths.push(pathPart);
+    }
+  }
+  return [...new Set(filePaths)];
+}
+
+// ─── Task File Parser ─────────────────────────────────────────
+
+interface ParsedTaskFile {
+  taskNumber: number | null;
+  taskName: string | null;
+  agentRole: string | null;
+  wave: number | null;
+  blockedBy: number[];
+  fileScope: string[];
+}
+
+export function parseTaskFile(content: string): ParsedTaskFile {
+  const result: ParsedTaskFile = {
+    taskNumber: null,
+    taskName: null,
+    agentRole: null,
+    wave: null,
+    blockedBy: [],
+    fileScope: [],
+  };
+
+  // Extract frontmatter block
+  const frontmatterMatch = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (frontmatterMatch) {
+    const fm = frontmatterMatch[1];
+
+    const taskNumberMatch = /^taskNumber:\s*(\d+)/m.exec(fm);
+    if (taskNumberMatch) result.taskNumber = parseInt(taskNumberMatch[1], 10);
+
+    const agentRoleMatch = /^agentRole:\s*"?([^"\n]+)"?/m.exec(fm);
+    if (agentRoleMatch) result.agentRole = agentRoleMatch[1].trim();
+
+    const waveMatch = /^wave:\s*(\d+)/m.exec(fm);
+    if (waveMatch) result.wave = parseInt(waveMatch[1], 10);
+
+    const blockedByMatch = /^blockedBy:\s*\[([^\]]*)\]/m.exec(fm);
+    if (blockedByMatch) {
+      const items = blockedByMatch[1].split(',').map((s) => s.trim()).filter(Boolean);
+      result.blockedBy = items.map(Number).filter((n) => !Number.isNaN(n));
+    }
+  }
+
+  // Extract task name from heading: "# Task #N: <name>"
+  const headingMatch = /^# Task #\d+:\s*(.+)$/m.exec(content);
+  if (headingMatch) result.taskName = headingMatch[1].trim();
+
+  // Extract file scope
+  result.fileScope = extractFileScope(content);
+
+  return result;
+}
+
+// ─── Tracking Index ───────────────────────────────────────────
+
+interface TrackingIndexEntry {
+  feature: string;
+  status: string;
+  branch: string | null;
+  agentCount: number;
+}
+
+interface TrackingIndex {
+  features: TrackingIndexEntry[];
+}
+
+export function readTrackingIndex(projectPath: string): TrackingIndex | null {
+  const indexPath = join(projectPath, '.claude', 'tracking', 'index.json');
+  if (!existsSync(indexPath)) return null;
+  try {
+    const raw = readFileSync(indexPath, 'utf-8');
+    return JSON.parse(raw) as TrackingIndex;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Feature Manifest ─────────────────────────────────────────
+
+interface ManifestAgent {
+  status: string;
+}
+
+interface FeatureManifest {
+  feature: string;
+  agents: Record<string, ManifestAgent>;
+}
+
+export function readFeatureManifest(projectPath: string, feature: string): FeatureManifest | null {
+  const manifestPath = join(projectPath, '.claude', 'tracking', feature, 'manifest.json');
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const raw = readFileSync(manifestPath, 'utf-8');
+    return JSON.parse(raw) as FeatureManifest;
+  } catch {
+    return null;
+  }
+}
+
+// ─── JSONL Tail Reader ────────────────────────────────────────
+
+const CHUNK_SIZE = 8192;
+const MAX_LINES = 200;
+
+/** Scans a buffer backward for newlines and returns the trim start offset, or -1. */
+function scanChunkForBoundary(
+  buf: Buffer,
+  readSize: number,
+  newlineCount: number,
+): { boundary: number; newlineCount: number } {
+  let count = newlineCount;
+  for (let i = readSize - 1; i >= 0; i--) {
+    if (buf[i] === 0x0a) {
+      count++;
+      if (count > MAX_LINES) {
+        return { boundary: i + 1, newlineCount: count };
+      }
+    }
+  }
+  return { boundary: -1, newlineCount: count };
+}
+
+/** Parses raw JSONL text into TrackingEvent objects, skipping malformed lines. */
+function parseJsonlLines(text: string): TrackingEvent[] {
+  const events: TrackingEvent[] = [];
+  for (const line of text.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      events.push(JSON.parse(line) as TrackingEvent);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return events;
+}
+
+/** Tail-reads fd backward in chunks, collecting buffers for the last MAX_LINES lines. */
+function tailReadFd(fd: number, fileSize: number): Buffer[] {
+  const chunks: Buffer[] = [];
+  let remaining = fileSize;
+  let newlineCount = 0;
+
+  while (remaining > 0) {
+    const readSize = Math.min(CHUNK_SIZE, remaining);
+    remaining -= readSize;
+    const buf = Buffer.alloc(readSize);
+    readSync(fd, buf, 0, readSize, remaining);
+
+    const { boundary, newlineCount: updatedCount } = scanChunkForBoundary(
+      buf,
+      readSize,
+      newlineCount,
+    );
+    newlineCount = updatedCount;
+
+    if (boundary >= 0) {
+      chunks.unshift(buf.subarray(boundary));
+      break;
+    }
+    chunks.unshift(buf);
+  }
+
+  return chunks;
+}
+
+/**
+ * Reads the last MAX_LINES lines of a JSONL file using backward seeks.
+ * Avoids loading the full file into memory.
+ */
+export function parseEventsJsonl(filePath: string): TrackingEvent[] {
+  if (!existsSync(filePath)) return [];
+
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(filePath);
+  } catch {
+    return [];
+  }
+
+  const fileSize = stat.size;
+  if (fileSize === 0) return [];
+
+  let fd: number;
+  try {
+    fd = openSync(filePath, 'r');
+  } catch {
+    return [];
+  }
+
+  try {
+    const chunks = tailReadFd(fd, fileSize);
+    const text = Buffer.concat(chunks).toString('utf-8');
+    return parseJsonlLines(text);
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // ignore close errors
+    }
+  }
+}
+
+// ─── Per-Agent JSONL ──────────────────────────────────────────
+
+interface AgentEvent {
+  ts: string;
+  type: string;
+  sid: string;
+}
+
+function readAgentEvents(projectPath: string, feature: string, agentName: string): AgentEvent[] {
+  const filePath = join(
+    projectPath,
+    '.claude',
+    'tracking',
+    feature,
+    'agents',
+    `${agentName}.jsonl`,
+  );
+  if (!existsSync(filePath)) return [];
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    const events: AgentEvent[] = [];
+    for (const line of lines) {
+      try {
+        events.push(JSON.parse(line) as AgentEvent);
+      } catch {
+        // skip
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+// ─── Status Derivation ────────────────────────────────────────
+
+const ACTIVE_WINDOW_MS = 120_000;
+
+export function deriveAgentStatus(agentEvents: AgentEvent[]): AgentStatus {
+  if (agentEvents.length === 0) return 'pending';
+
+  // Find last agent.idle event
+  let lastIdleTs: string | null = null;
+  for (let i = agentEvents.length - 1; i >= 0; i--) {
+    if (agentEvents[i].type === 'agent.idle') {
+      lastIdleTs = agentEvents[i].ts;
+      break;
+    }
+  }
+
+  if (lastIdleTs !== null) {
+    const age = Date.now() - new Date(lastIdleTs).getTime();
+    if (age <= ACTIVE_WINDOW_MS) return 'active';
+    return 'idle';
+  }
+
+  // Check for completion or error events
+  const lastEvent = agentEvents.at(-1);
+  if (!lastEvent) return 'pending';
+  if (lastEvent.type === 'agent.completed' || lastEvent.type === 'task.completed') {
+    return 'completed';
+  }
+  if (lastEvent.type === 'agent.error') return 'error';
+
+  return 'pending';
+}
+
+// ─── Task File Finder ─────────────────────────────────────────
+
+function findTaskFileContent(
+  projectPath: string,
+  feature: string,
+  taskNumber: number | null,
+): string | null {
+  if (taskNumber === null) return null;
+  const taskDir = join(projectPath, '.claude', 'progress', feature, 'tasks');
+  if (!existsSync(taskDir)) return null;
+
+  // Try common patterns: task-1.md, task-1a.md, task-1b.md
+  const candidates = [
+    join(taskDir, `task-${taskNumber}.md`),
+    join(taskDir, `task-${taskNumber}a.md`),
+    join(taskDir, `task-${taskNumber}b.md`),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      try {
+        return readFileSync(c, 'utf-8');
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Feature Builder ──────────────────────────────────────────
+
+function buildFeatureData(
+  projectPath: string,
+  entry: TrackingIndexEntry,
+): FeatureAgentData {
+  const { feature, status, branch } = entry;
+
+  const manifest = readFeatureManifest(projectPath, feature);
+  const agentNames = manifest ? Object.keys(manifest.agents) : [];
+
+  const eventsPath = join(projectPath, '.claude', 'tracking', feature, 'events.jsonl');
+  const events = parseEventsJsonl(eventsPath);
+
+  const tasks: AgentTaskInfo[] = agentNames.map((agentName) => {
+    const taskNumber = agentNameToTaskNumber(agentName);
+    const agentEvents = readAgentEvents(projectPath, feature, agentName);
+
+    const lastEvent = agentEvents.at(-1) ?? null;
+    const lastEventTs = lastEvent ? lastEvent.ts : null;
+    const lastSid = lastEvent ? lastEvent.sid : null;
+
+    const taskContent = findTaskFileContent(projectPath, feature, taskNumber);
+    const parsed = taskContent ? parseTaskFile(taskContent) : null;
+
+    const agentRole = parsed?.agentRole ?? null;
+    const isGuardian =
+      agentName.startsWith('guardian') || agentRole === 'codebase-guardian';
+
+    return {
+      agentName,
+      taskNumber: parsed?.taskNumber ?? taskNumber,
+      taskName: parsed?.taskName ?? null,
+      agentRole,
+      wave: parsed?.wave ?? null,
+      blockedBy: parsed?.blockedBy ?? [],
+      status: deriveAgentStatus(agentEvents),
+      lastEventTs,
+      lastSid,
+      fileScope: parsed?.fileScope ?? [],
+      eventCount: agentEvents.length,
+      isGuardian,
+    };
+  });
+
+  return {
+    feature,
+    status,
+    branch: branch ?? null,
+    agentCount: agentNames.length,
+    tasks,
+    events,
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────
+
+export function buildAgentTeamsData(projectPath: string): AgentTeamsData {
+  const trackingDir = join(projectPath, '.claude', 'tracking');
+
+  if (!existsSync(trackingDir)) {
+    return { projectPath, features: [], hasTrackingDir: false };
+  }
+
+  const index = readTrackingIndex(projectPath);
+  if (!index) {
+    return { projectPath, features: [], hasTrackingDir: true };
+  }
+
+  const features: FeatureAgentData[] = [];
+  for (const entry of index.features) {
+    try {
+      features.push(buildFeatureData(projectPath, entry));
+    } catch {
+      // Skip features that fail to load — graceful degradation
+    }
+  }
+
+  return { projectPath, features, hasTrackingDir: true };
+}

--- a/src/main/services/visualization/codebase-graph.ts
+++ b/src/main/services/visualization/codebase-graph.ts
@@ -1,0 +1,212 @@
+/**
+ * Codebase Graph Builder
+ *
+ * Builds a dependency graph for an arbitrary project by:
+ * 1. Detecting the project framework from package.json
+ * 2. Collecting all source files
+ * 3. Parsing import specifiers via regex
+ * 4. Resolving specifiers to absolute paths
+ * 5. Grouping files by directory structure
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, extname, join, relative } from 'node:path';
+
+import {
+  collectSourceFiles,
+  extractImportSpecifiers,
+  loadTsconfigPaths,
+  resolveSpecifier,
+} from './import-parser';
+
+import type { CodebaseEdge, CodebaseFile, CodebaseGraph } from './types';
+
+// ─── Framework Detection ─────────────────────────────────────
+
+/**
+ * Detects the frontend/backend framework used in a project by inspecting package.json.
+ * Returns one of: 'electron', 'nextjs', 'vite-spa', 'node-server', 'unknown'.
+ */
+export function detectFramework(projectPath: string): string {
+  const pkgPath = join(projectPath, 'package.json');
+  if (!existsSync(pkgPath)) return 'unknown';
+
+  try {
+    const raw = readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+
+    if ('electron-vite' in allDeps || 'electron' in allDeps) return 'electron';
+    if ('next' in allDeps) return 'nextjs';
+    if ('vite' in allDeps) return 'vite-spa';
+    if ('express' in allDeps || 'fastify' in allDeps || 'koa' in allDeps)
+      return 'node-server';
+
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** Returns the segment after a path prefix (e.g. "src/main/services/" → first dir name). */
+function segmentAfter(p: string, prefix: string): string {
+  return p.slice(prefix.length).split('/')[0] ?? 'unknown';
+}
+
+/**
+ * Determines the file group for an electron-framework project.
+ * Returns null if no electron-specific rule matches.
+ */
+function getElectronGroup(p: string): string | null {
+  if (p.startsWith('src/renderer/features/')) {
+    return `features/${segmentAfter(p, 'src/renderer/features/')}`;
+  }
+  if (p.startsWith('src/main/services/')) {
+    return `main/services/${segmentAfter(p, 'src/main/services/')}`;
+  }
+  if (p.startsWith('src/main/ipc/')) return 'main/ipc';
+  if (p.startsWith('src/main/bootstrap/')) return 'main/bootstrap';
+  if (p.startsWith('src/main/')) return 'main';
+  if (p.startsWith('src/shared/')) return 'shared';
+  if (p.startsWith('src/preload/')) return 'preload';
+  if (p.startsWith('src/renderer/')) {
+    const subdir = segmentAfter(p, 'src/renderer/');
+    return subdir ? `renderer/${subdir}` : 'renderer';
+  }
+  return null;
+}
+
+/**
+ * Determines the display group for a file given a framework.
+ *
+ * For 'electron' framework:
+ * - src/renderer/features/<name>/... → 'features/<name>'
+ * - src/main/services/<name>/... → 'main/services/<name>'
+ * - src/main/ipc/... → 'main/ipc'
+ * - src/main/bootstrap/... → 'main/bootstrap'
+ * - src/shared/... → 'shared'
+ * - src/preload/... → 'preload'
+ * - other src/renderer/... → 'renderer/<subdir>'
+ * - anything else → 'other'
+ */
+export function getFileGroup(relativePath: string, framework: string): string {
+  // Normalize separators to forward slashes
+  const p = relativePath.replaceAll('\\', '/');
+
+  if (framework === 'electron') {
+    const group = getElectronGroup(p);
+    if (group !== null) return group;
+  }
+
+  // Generic fallback: use top-level directory as group
+  const parts = p.split('/');
+  return parts.length > 1 && parts[0] ? parts[0] : 'other';
+}
+
+// ─── Graph Builder ───────────────────────────────────────────
+
+/**
+ * Builds a complete codebase dependency graph for the given project.
+ *
+ * Scans `{projectPath}/src/` (falls back to `{projectPath}/` if no src/ dir),
+ * parses all import specifiers with regex, resolves them to absolute paths,
+ * and groups files by framework-aware directory structure.
+ *
+ * Handles missing tsconfig.json, missing src/ dir, and empty projects gracefully —
+ * returns an empty graph rather than throwing.
+ */
+export function buildCodebaseGraph(projectPath: string): CodebaseGraph {
+  const startMs = Date.now();
+
+  // Determine scan root: prefer src/ subdirectory
+  const srcDir = join(projectPath, 'src');
+  const scanRoot = existsSync(srcDir) ? srcDir : projectPath;
+
+  // Detect framework
+  const framework = detectFramework(projectPath);
+
+  // Load tsconfig path aliases
+  const pathConfig = loadTsconfigPaths(projectPath);
+
+  // Collect all source files
+  let allFiles: string[];
+  try {
+    allFiles = collectSourceFiles(scanRoot);
+  } catch {
+    allFiles = [];
+  }
+
+  if (allFiles.length === 0) {
+    return {
+      projectPath,
+      framework,
+      files: [],
+      edges: [],
+      groups: [],
+      buildTimeMs: Date.now() - startMs,
+    };
+  }
+
+  // Build a set for O(1) membership checks during resolution
+  const fileSet = new Set(allFiles);
+
+  // Accumulate import counts keyed by absolute path
+  const importCounts = new Map<string, number>();
+  for (const f of allFiles) {
+    importCounts.set(f, 0);
+  }
+
+  // Parse imports and build edges
+  const edges: CodebaseEdge[] = [];
+
+  for (const filePath of allFiles) {
+    let src: string;
+    try {
+      src = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const specifiers = extractImportSpecifiers(src);
+    for (const specifier of specifiers) {
+      const resolved = resolveSpecifier(specifier, filePath, pathConfig);
+      if (resolved !== null && fileSet.has(resolved) && resolved !== filePath) {
+        edges.push({ source: filePath, target: resolved });
+        importCounts.set(resolved, (importCounts.get(resolved) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Build file records
+  const groupSet = new Set<string>();
+  const files: CodebaseFile[] = allFiles.map((absPath) => {
+    const rel = relative(projectPath, absPath).replaceAll('\\', '/');
+    const group = getFileGroup(rel, framework);
+    groupSet.add(group);
+
+    return {
+      path: absPath,
+      relativePath: rel,
+      fileName: basename(absPath),
+      ext: extname(absPath),
+      group,
+      importCount: importCounts.get(absPath) ?? 0,
+    };
+  });
+
+  return {
+    projectPath,
+    framework,
+    files,
+    edges,
+    groups: [...groupSet],
+    buildTimeMs: Date.now() - startMs,
+  };
+}

--- a/src/main/services/visualization/import-parser.ts
+++ b/src/main/services/visualization/import-parser.ts
@@ -1,0 +1,255 @@
+/**
+ * Import Parser
+ *
+ * Regex-based static import extractor and path resolver.
+ * Reads source files and extracts all import/require/export-from specifiers,
+ * then resolves them to absolute paths.
+ *
+ * Does NOT use ts.createProgram, ts-morph, or dependency-cruiser.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, extname, isAbsolute, join, resolve } from 'node:path';
+
+import type { PathConfig } from './types';
+
+// ─── Constants ──────────────────────────────────────────────
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'out',
+  'build',
+  '.next',
+  '.worktrees',
+  'coverage',
+]);
+
+/** Resolution suffixes tried in order when a bare path has no extension. */
+const RESOLUTION_SUFFIXES = [
+  '',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '/index.ts',
+  '/index.tsx',
+  '/index.js',
+  '/index.jsx',
+] as const;
+
+// ─── Regex Patterns ──────────────────────────────────────────
+
+/** Matches: import X from '...', import type X from '...', import { X } from '...' */
+const FROM_RE = /\bimport\s+(?:type\s+)?(?:[\s\S]*?\bfrom\s+)?['"]([^'"]+)['"]/gm;
+
+/** Matches: import('...') */
+const DYN_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+/** Matches: require('...') */
+const REQ_RE = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+/** Matches: export { X } from '...', export * from '...', export * as X from '...' */
+const EXPORT_RE =
+  /\bexport\s+(?:type\s+)?(?:\{[^}]*\}|\*(?:\s+as\s+\w+)?)\s+from\s+['"]([^'"]+)['"]/gm;
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+/**
+ * Runs a regex (with g flag) against source and returns all captured group[1] values.
+ * Resets lastIndex before each call to ensure correctness.
+ */
+function matchAll(re: RegExp, src: string): string[] {
+  re.lastIndex = 0;
+  const results: string[] = [];
+  let m = re.exec(src);
+  while (m !== null) {
+    if (m[1]) results.push(m[1]);
+    m = re.exec(src);
+  }
+  return results;
+}
+
+// ─── Public API ──────────────────────────────────────────────
+
+/**
+ * Extracts all import specifier strings from a TypeScript/JavaScript source string.
+ * Handles: static imports, type imports, dynamic imports, require(), export-from.
+ */
+export function extractImportSpecifiers(src: string): string[] {
+  const seen = new Set<string>();
+  const add = (s: string): void => {
+    seen.add(s);
+  };
+
+  matchAll(FROM_RE, src).forEach(add);
+  matchAll(DYN_RE, src).forEach(add);
+  matchAll(REQ_RE, src).forEach(add);
+  matchAll(EXPORT_RE, src).forEach(add);
+
+  return [...seen];
+}
+
+/**
+ * Reads tsconfig.json from the project root and extracts path aliases and baseUrl.
+ * Returns empty config if tsconfig.json is missing or malformed.
+ */
+export function loadTsconfigPaths(projectRoot: string): PathConfig {
+  const tsconfigPath = join(projectRoot, 'tsconfig.json');
+
+  if (!existsSync(tsconfigPath)) {
+    return { paths: {}, baseUrl: null };
+  }
+
+  try {
+    const raw = readFileSync(tsconfigPath, 'utf-8');
+    // Strip single-line comments and trailing commas (common in tsconfig.json)
+    const noComments = raw.replaceAll(/\/\/[^\n]*/g, '');
+    const stripped = noComments.replaceAll(/,\s*([}\]])/g, '$1');
+    const parsed = JSON.parse(stripped) as {
+      compilerOptions?: {
+        paths?: Record<string, string[]>;
+        baseUrl?: string;
+      };
+    };
+    const opts = parsed.compilerOptions ?? {};
+    const rawPaths = opts.paths ?? {};
+    const rawBaseUrl = opts.baseUrl ?? null;
+
+    // Resolve each path alias entry relative to tsconfig location
+    const tsconfigDir = dirname(tsconfigPath);
+    const resolvedPaths: Record<string, string[]> = {};
+    for (const [alias, mappings] of Object.entries(rawPaths)) {
+      // Strip trailing /* from alias (e.g. "@shared/*" → "@shared")
+      const cleanAlias = alias.endsWith('/*') ? alias.slice(0, -2) : alias;
+      resolvedPaths[cleanAlias] = mappings.map((m) => {
+        const cleanMapping = m.endsWith('/*') ? m.slice(0, -2) : m;
+        return resolve(tsconfigDir, cleanMapping);
+      });
+    }
+
+    const baseUrl =
+      rawBaseUrl === null ? null : resolve(tsconfigDir, rawBaseUrl);
+
+    return { paths: resolvedPaths, baseUrl };
+  } catch {
+    return { paths: {}, baseUrl: null };
+  }
+}
+
+/**
+ * Attempts to resolve a non-relative specifier using tsconfig path aliases.
+ * Returns:
+ *   - a resolved absolute path if the alias matched and a file was found
+ *   - `{ aliasMatched: true }` if the alias matched but no file was found
+ *   - `null` if no alias matched
+ */
+function resolveViaAlias(
+  specifier: string,
+  pathConfig: PathConfig,
+): string | { aliasMatched: true } | null {
+  for (const [alias, targets] of Object.entries(pathConfig.paths)) {
+    if (specifier === alias || specifier.startsWith(`${alias}/`)) {
+      const rest = specifier.slice(alias.length);
+      for (const target of targets) {
+        const resolved = tryResolvePath(target + rest);
+        if (resolved !== null) return resolved;
+      }
+      return { aliasMatched: true };
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves an import specifier to an absolute file path.
+ * Returns null if the specifier refers to an external package (not a local file).
+ *
+ * Resolution order:
+ * 1. Relative specifiers (starting with './' or '../') — resolved against fromFile dir
+ * 2. Absolute specifiers — used as-is
+ * 3. Alias specifiers — matched against tsconfig paths, resolved to absolute
+ * 4. Anything else is treated as an external package → returns null
+ */
+export function resolveSpecifier(
+  specifier: string,
+  fromFile: string,
+  pathConfig: PathConfig,
+): string | null {
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    return tryResolvePath(resolve(dirname(fromFile), specifier));
+  }
+
+  if (isAbsolute(specifier)) {
+    return tryResolvePath(specifier);
+  }
+
+  // Try path alias resolution
+  const aliasResult = resolveViaAlias(specifier, pathConfig);
+  if (aliasResult !== null) {
+    // If aliasMatched is set, the alias matched but no file was found — treat as external
+    return typeof aliasResult === 'string' ? aliasResult : null;
+  }
+
+  // Try baseUrl resolution
+  if (pathConfig.baseUrl !== null) {
+    const resolved = tryResolvePath(join(pathConfig.baseUrl, specifier));
+    if (resolved !== null) return resolved;
+  }
+
+  // External package
+  return null;
+}
+
+/**
+ * Tries all resolution suffixes for a base path and returns the first match,
+ * or null if no match is found.
+ */
+function tryResolvePath(base: string): string | null {
+  for (const suffix of RESOLUTION_SUFFIXES) {
+    const candidate = base + suffix;
+    if (existsSync(candidate) && SOURCE_EXTENSIONS.has(extname(candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Recursively collects all TypeScript/JavaScript source files under `dir`.
+ * Skips node_modules, .git, dist, out, build, .next, .worktrees, and coverage.
+ * Returns an array of absolute file paths.
+ */
+export function collectSourceFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(current: string): void {
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+
+      const fullPath = join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        const ext = extname(entry.name);
+        if (SOURCE_EXTENSIONS.has(ext)) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}

--- a/src/main/services/visualization/index.ts
+++ b/src/main/services/visualization/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Visualization Service
+ *
+ * Factory for the VisualizationService interface.
+ * Provides codebase graph building and stubs for agent teams and session log
+ * (implemented by Task 3).
+ */
+
+import { buildAgentTeamsData } from './agent-teams';
+import { buildCodebaseGraph } from './codebase-graph';
+import { buildSessionLog } from './session-log';
+
+import type {
+  AgentTeamsData,
+  CodebaseGraph,
+  SessionLogPage,
+} from './types';
+
+// ─── Service Interface ────────────────────────────────────────
+
+export interface VisualizationService {
+  /**
+   * Builds a codebase dependency graph for the given project directory.
+   * Reads source files synchronously and returns the full graph.
+   */
+  getCodebaseGraph: (projectPath: string) => CodebaseGraph;
+
+  /**
+   * Returns agent teams data for the given project.
+   * Reads .claude/tracking/ from the project path.
+   *
+   * @throws Error('Not implemented') — implemented in Task 3
+   */
+  getAgentTeams: (projectPath: string) => AgentTeamsData;
+
+  /**
+   * Returns a paginated page of a Claude session log.
+   *
+   * @throws Error('Not implemented') — implemented in Task 3
+   */
+  getSessionLog: (opts: {
+    projectPath: string;
+    feature: string;
+    agentName: string;
+    sid?: string | null;
+    cursor?: number;
+  }) => SessionLogPage;
+}
+
+// ─── Factory ──────────────────────────────────────────────────
+
+/**
+ * Creates a VisualizationService instance.
+ * The service is stateless — each call reads from disk and returns.
+ * No constructor dependencies required.
+ */
+export function createVisualizationService(): VisualizationService {
+  return {
+    getCodebaseGraph(projectPath: string): CodebaseGraph {
+      return buildCodebaseGraph(projectPath);
+    },
+
+    getAgentTeams(projectPath: string): AgentTeamsData {
+      return buildAgentTeamsData(projectPath);
+    },
+
+    getSessionLog(opts: {
+      projectPath: string;
+      feature: string;
+      agentName: string;
+      sid?: string | null;
+      cursor?: number;
+    }): SessionLogPage {
+      return buildSessionLog({
+        projectPath: opts.projectPath,
+        agentName: opts.agentName,
+        feature: opts.feature,
+        sid: opts.sid ?? null,
+        cursor: opts.cursor ?? 0,
+      });
+    },
+  };
+}

--- a/src/main/services/visualization/session-log.ts
+++ b/src/main/services/visualization/session-log.ts
@@ -1,0 +1,206 @@
+/**
+ * Session Log Reader
+ *
+ * Reads Claude session JSONL files from ~/.claude/projects/{encodedPath}/
+ * matching by session ID prefix from tracking events.
+ */
+
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { SessionLogLine, SessionLogPage } from './types';
+
+// ─── Path Encoding ────────────────────────────────────────────
+
+/**
+ * Encodes a project path for use as a directory name under ~/.claude/projects/.
+ *
+ * Windows: C:\Users\foo\app → C--Users-foo-app
+ * Unix:    /Users/foo/app  → Users-foo-app
+ */
+export function encodeProjectPath(projectPath: string): string {
+  return projectPath
+    .replaceAll(/^[/\\]+/u, '') // strip leading separator(s)
+    .replaceAll(/[/\\]/gu, '-') // replace all separators with -
+    .replaceAll(':', '-'); // replace Windows drive colon
+}
+
+// ─── Session File Finder ──────────────────────────────────────
+
+function getClaudeProjectsDir(): string {
+  return join(homedir(), '.claude', 'projects');
+}
+
+/**
+ * Finds a session JSONL file by matching the sid prefix.
+ * Session files are named like <sid>.jsonl under ~/.claude/projects/{encodedPath}/.
+ */
+export function findSessionFile(
+  projectPath: string,
+  sid: string | null,
+): string | null {
+  if (!sid) return null;
+
+  const encodedPath = encodeProjectPath(projectPath);
+  const projectDir = join(getClaudeProjectsDir(), encodedPath);
+
+  if (!existsSync(projectDir)) return null;
+
+  const candidate = join(projectDir, `${sid}.jsonl`);
+  if (existsSync(candidate)) return candidate;
+
+  // Try prefix match — sid in tracking may be truncated
+  try {
+    const entries = readdirSync(projectDir);
+    for (const entry of entries) {
+      if (entry.endsWith('.jsonl') && entry.startsWith(sid)) {
+        return join(projectDir, entry);
+      }
+    }
+  } catch {
+    // ignore read errors
+  }
+
+  return null;
+}
+
+// ─── Session Log Pagination ───────────────────────────────────
+
+const PAGE_SIZE = 100;
+
+interface BuildSessionLogOpts {
+  projectPath: string;
+  agentName: string;
+  feature: string;
+  /** Session ID prefix to locate the file, or null */
+  sid: string | null;
+  /** Byte offset cursor from previous page, or 0 for first page */
+  cursor: number;
+}
+
+/** Finds the line index corresponding to a byte offset in an array of lines. */
+function findStartLineIndex(allLines: string[], cursor: number): { index: number; bytePos: number } {
+  let bytePos = 0;
+  for (const [i, line] of allLines.entries()) {
+    if (bytePos >= cursor) {
+      return { index: i, bytePos };
+    }
+    bytePos += Buffer.byteLength(line, 'utf-8') + 1; // +1 for \n
+  }
+  return { index: allLines.length, bytePos };
+}
+
+/** Parses a single JSONL line into a SessionLogLine. */
+function parseSessionLine(line: string, index: number): SessionLogLine {
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    // keep parsed as null
+  }
+  return {
+    index,
+    raw: line,
+    ts: typeof parsed?.ts === 'string' ? parsed.ts : undefined,
+    type: typeof parsed?.type === 'string' ? parsed.type : undefined,
+  };
+}
+
+/** Checks if any non-empty line exists after the given start index. */
+function hasMoreLines(allLines: string[], fromIndex: number): boolean {
+  for (let i = fromIndex; i < allLines.length; i++) {
+    if (allLines[i].trim().length > 0) return true;
+  }
+  return false;
+}
+
+/** Reads a page of lines from startLineIndex, accumulating byte offset. */
+function readPage(
+  allLines: string[],
+  startLineIndex: number,
+  startBytePos: number,
+): { pageLines: SessionLogLine[]; nextByteOffset: number; processedLines: number } {
+  const pageLines: SessionLogLine[] = [];
+  let nextByteOffset = startBytePos;
+  let processedLines = 0;
+
+  for (let i = startLineIndex; i < allLines.length && processedLines < PAGE_SIZE; i++) {
+    const line = allLines[i];
+    const lineByteLen = Buffer.byteLength(line, 'utf-8') + 1;
+
+    if (line.trim().length === 0) {
+      nextByteOffset += lineByteLen;
+      continue;
+    }
+
+    pageLines.push(parseSessionLine(line, i));
+    nextByteOffset += lineByteLen;
+    processedLines++;
+  }
+
+  return { pageLines, nextByteOffset, processedLines };
+}
+
+/**
+ * Reads a page of session log lines starting at `cursor` byte offset.
+ * Returns cursor=-1 when there are no more lines.
+ */
+export function buildSessionLog(opts: BuildSessionLogOpts): SessionLogPage {
+  const { projectPath, agentName, feature, sid, cursor } = opts;
+
+  const empty: SessionLogPage = {
+    agentName,
+    feature,
+    lines: [],
+    total: 0,
+    cursor: -1,
+    sessionFile: null,
+  };
+
+  const sessionFile = findSessionFile(projectPath, sid);
+  if (!sessionFile) return empty;
+
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(sessionFile);
+  } catch {
+    return empty;
+  }
+
+  if (stat.size === 0) return { ...empty, sessionFile };
+
+  let fd: number;
+  try {
+    fd = openSync(sessionFile, 'r');
+  } catch {
+    return { ...empty, sessionFile };
+  }
+
+  try {
+    const raw = readFileSync(sessionFile, 'utf-8');
+    const allLines = raw.split('\n');
+    const totalLines = allLines.filter((l) => l.trim().length > 0).length;
+
+    const { index: startLineIndex, bytePos } = findStartLineIndex(allLines, cursor);
+    const { pageLines, nextByteOffset, processedLines } = readPage(allLines, startLineIndex, bytePos);
+
+    const afterPageIndex = startLineIndex + processedLines;
+    const nextCursor = hasMoreLines(allLines, afterPageIndex) ? nextByteOffset : -1;
+
+    return {
+      agentName,
+      feature,
+      lines: pageLines,
+      total: totalLines,
+      cursor: nextCursor,
+      sessionFile,
+    };
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // ignore close errors
+    }
+  }
+}

--- a/src/main/services/visualization/types.ts
+++ b/src/main/services/visualization/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Visualization Service Types
+ *
+ * TypeScript interfaces for the Visualization service.
+ * These match the shape of the Zod schemas defined in
+ * src/shared/ipc/visualization/contract.ts.
+ */
+
+// ─── Codebase Graph ──────────────────────────────────────────
+
+/** A single source file found in the scanned project. */
+export interface CodebaseFile {
+  /** Absolute path to the file. */
+  path: string;
+  /** Path relative to the project root. */
+  relativePath: string;
+  /** Basename (e.g. "task-service.ts"). */
+  fileName: string;
+  /** File extension including dot (e.g. ".ts"). */
+  ext: string;
+  /** Detected group (e.g. "features/tasks", "main/services/project"). */
+  group: string;
+  /** Number of other files in the project that import this file. */
+  importCount: number;
+}
+
+/** A directed import relationship between two files. */
+export interface CodebaseEdge {
+  /** Absolute path of the importing file. */
+  source: string;
+  /** Absolute path of the imported file. */
+  target: string;
+}
+
+/** Full codebase dependency graph for a project. */
+export interface CodebaseGraph {
+  /** Absolute path to the project root. */
+  projectPath: string;
+  /** Detected framework (e.g. "electron", "nextjs", "vite-spa", "node-server", "unknown"). */
+  framework: string;
+  /** All source files discovered in the project. */
+  files: CodebaseFile[];
+  /** All resolved import edges between files. */
+  edges: CodebaseEdge[];
+  /** Unique group names in discovery order. */
+  groups: string[];
+  /** Time taken to build the graph, in milliseconds. */
+  buildTimeMs: number;
+}
+
+// ─── Path Config ─────────────────────────────────────────────
+
+/** Resolved tsconfig paths used for alias resolution. */
+export interface PathConfig {
+  /** Map from alias prefix (e.g. "@shared") to array of resolved base paths. */
+  paths: Record<string, string[]>;
+  /** Base URL from tsconfig, if any. */
+  baseUrl: string | null;
+}
+
+// ─── Agent Teams ─────────────────────────────────────────────
+
+/** Live status of an agent derived from tracking events. */
+export type AgentStatus = 'pending' | 'active' | 'idle' | 'completed' | 'error';
+
+/** A single event from a tracking JSONL file. */
+export interface TrackingEvent {
+  /** ISO timestamp. */
+  ts: string;
+  /** Event type (e.g. "agent_start", "tool_call"). */
+  type: string;
+  /** Agent name, or null for team-level events. */
+  agent: string | null;
+  /** Session ID associated with the event. */
+  sid: string;
+  /** Arbitrary event payload. */
+  data: Record<string, unknown>;
+}
+
+/** Information about a single agent task within a feature. */
+export interface AgentTaskInfo {
+  /** Agent name from the manifest (e.g. "coder-task-1"). */
+  agentName: string;
+  /** Task number from the task file frontmatter, or null. */
+  taskNumber: number | null;
+  /** Task name from the task file frontmatter, or null. */
+  taskName: string | null;
+  /** Agent role from the task file frontmatter, or null. */
+  agentRole: string | null;
+  /** Wave number from the task file frontmatter, or null. */
+  wave: number | null;
+  /** Task numbers that must complete before this task can start. */
+  blockedBy: number[];
+  /** Derived live status of this agent. */
+  status: AgentStatus;
+  /** ISO timestamp of the last event, or null. */
+  lastEventTs: string | null;
+  /** Last known session ID prefix for log lookup, or null. */
+  lastSid: string | null;
+  /** Files this agent is scoped to touch (from task .md ## Files sections). */
+  fileScope: string[];
+  /** Total number of events recorded for this agent. */
+  eventCount: number;
+  /** Whether this agent is a guardian/QA agent. */
+  isGuardian: boolean;
+}
+
+/** All agent team data for a single feature. */
+export interface FeatureAgentData {
+  /** Feature slug. */
+  feature: string;
+  /** Feature status from tracking index. */
+  status: string;
+  /** Branch associated with this feature, or null. */
+  branch: string | null;
+  /** Total number of agent tasks in this feature. */
+  agentCount: number;
+  /** All agent task records. */
+  tasks: AgentTaskInfo[];
+  /** Most recent 200 events from events.jsonl. */
+  events: TrackingEvent[];
+}
+
+/** Agent teams data for the entire project. */
+export interface AgentTeamsData {
+  /** Absolute path to the project root. */
+  projectPath: string;
+  /** All features found in .claude/tracking/index.json. */
+  features: FeatureAgentData[];
+  /** Whether a .claude/tracking/ directory exists in the project. */
+  hasTrackingDir: boolean;
+}
+
+// ─── Session Log ─────────────────────────────────────────────
+
+/** A single line from a Claude session JSONL file. */
+export interface SessionLogLine {
+  /** Zero-based line index within the file. */
+  index: number;
+  /** Raw JSON string from the JSONL file. */
+  raw: string;
+  /** Timestamp, if present in the parsed line. */
+  ts?: string;
+  /** Event type (e.g. "assistant", "user", "tool_use"). */
+  type?: string;
+}
+
+/** A paginated page of session log lines. */
+export interface SessionLogPage {
+  /** Agent name this log belongs to. */
+  agentName: string;
+  /** Feature slug this agent worked on. */
+  feature: string;
+  /** The log lines in this page. */
+  lines: SessionLogLine[];
+  /** Total number of lines in the file. */
+  total: number;
+  /** Next cursor (byte offset) for the following page, or -1 if at end. */
+  cursor: number;
+  /** Absolute path of the matched session file, or null. */
+  sessionFile: string | null;
+}

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -59,6 +59,7 @@ import { spotifyInvoke } from './spotify';
 import { hubTasksEvents, hubTasksInvoke, tasksEvents, tasksInvoke } from './tasks';
 import { terminalsEvents, terminalsInvoke } from './terminals';
 import { trackerInvoke } from './tracker';
+import { visualizationInvoke } from './visualization';
 import { windowInvoke } from './window';
 import { workflowEvents, workflowInvoke } from './workflow';
 import { workspaceEvents, workspaceInvoke } from './workspace';
@@ -113,6 +114,7 @@ export const ipcInvokeContract = {
   ...trackerInvoke,
   ...agentDashboardInvoke,
   ...workspaceInvoke,
+  ...visualizationInvoke,
 } as const;
 
 // ─── Merged Event Contract ───────────────────────────────────
@@ -440,3 +442,16 @@ export {
   WorkspaceSessionSchema,
   WorkspaceSessionStatusSchema,
 } from './workspace';
+
+export {
+  AgentStatusSchema,
+  AgentTaskInfoSchema,
+  AgentTeamsDataSchema,
+  CodebaseEdgeSchema,
+  CodebaseFileSchema,
+  CodebaseGraphSchema,
+  FeatureAgentDataSchema,
+  SessionLogLineSchema,
+  SessionLogPageSchema,
+  TrackingEventSchema,
+} from './visualization';

--- a/src/shared/ipc/visualization/contract.ts
+++ b/src/shared/ipc/visualization/contract.ts
@@ -1,0 +1,32 @@
+/**
+ * Visualization IPC Contract
+ *
+ * Defines invoke channels for the visualization domain:
+ * codebase dependency graph, agent teams data, and session log pagination.
+ */
+
+import { z } from 'zod';
+
+import { AgentTeamsDataSchema, CodebaseGraphSchema, SessionLogPageSchema } from './schemas';
+
+// ─── Invoke Channels ──────────────────────────────────────────────
+
+export const visualizationInvoke = {
+  'visualization.getCodebaseGraph': {
+    input: z.object({ projectId: z.string() }),
+    output: CodebaseGraphSchema,
+  },
+  'visualization.getAgentTeams': {
+    input: z.object({ projectId: z.string() }),
+    output: AgentTeamsDataSchema,
+  },
+  'visualization.getSessionLog': {
+    input: z.object({
+      projectId: z.string(),
+      feature: z.string(),
+      agentName: z.string(),
+      cursor: z.number().optional(),
+    }),
+    output: SessionLogPageSchema,
+  },
+} as const;

--- a/src/shared/ipc/visualization/index.ts
+++ b/src/shared/ipc/visualization/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Visualization IPC — Barrel Export
+ *
+ * Re-exports all visualization-related schemas and contract definitions.
+ */
+
+export {
+  AgentStatusSchema,
+  AgentTaskInfoSchema,
+  AgentTeamsDataSchema,
+  CodebaseEdgeSchema,
+  CodebaseFileSchema,
+  CodebaseGraphSchema,
+  FeatureAgentDataSchema,
+  SessionLogLineSchema,
+  SessionLogPageSchema,
+  TrackingEventSchema,
+} from './schemas';
+
+export { visualizationInvoke } from './contract';

--- a/src/shared/ipc/visualization/schemas.ts
+++ b/src/shared/ipc/visualization/schemas.ts
@@ -1,0 +1,113 @@
+/**
+ * Visualization IPC Schemas
+ *
+ * Zod schemas for the visualization domain: codebase dependency graphs,
+ * agent team tracking data, and session log pagination.
+ */
+
+import { z } from 'zod';
+
+// ─── Codebase Graph Schemas ───────────────────────────────────────
+
+/** A single file node in the codebase dependency graph */
+export const CodebaseFileSchema = z.object({
+  path: z.string().max(500),
+  relativePath: z.string().max(500),
+  fileName: z.string().max(500),
+  ext: z.string().max(500),
+  group: z.string().max(500),
+  importCount: z.number(),
+});
+
+/** A directed edge between two file nodes */
+export const CodebaseEdgeSchema = z.object({
+  source: z.string().max(500),
+  target: z.string().max(500),
+});
+
+/** Full codebase dependency graph for a project */
+export const CodebaseGraphSchema = z.object({
+  projectPath: z.string().max(500),
+  framework: z.string().max(500),
+  files: z.array(CodebaseFileSchema),
+  edges: z.array(CodebaseEdgeSchema),
+  groups: z.array(z.string().max(500)),
+  buildTimeMs: z.number(),
+});
+
+// ─── Agent Teams Schemas ──────────────────────────────────────────
+
+/** Status of a single agent task */
+export const AgentStatusSchema = z.enum([
+  'pending',
+  'active',
+  'idle',
+  'completed',
+  'error',
+]);
+
+/** A single tracking event emitted by an agent */
+export const TrackingEventSchema = z.object({
+  ts: z.string(),
+  type: z.string(),
+  agent: z.string().nullable(),
+  sid: z.string(),
+  data: z.record(z.string(), z.unknown()),
+});
+
+/** Metadata for a single agent task within a feature */
+export const AgentTaskInfoSchema = z.object({
+  agentName: z.string(),
+  taskNumber: z.number().nullable(),
+  taskName: z.string().nullable(),
+  agentRole: z.string().nullable(),
+  wave: z.number().nullable(),
+  blockedBy: z.array(z.number()),
+  status: AgentStatusSchema,
+  lastEventTs: z.string().nullable(),
+  lastSid: z.string().nullable(),
+  fileScope: z.array(z.string().max(500)),
+  eventCount: z.number(),
+  isGuardian: z.boolean(),
+});
+
+/** Aggregated data for all agents working on a single feature */
+export const FeatureAgentDataSchema = z.object({
+  feature: z.string(),
+  status: z.string(),
+  branch: z.string().nullable(),
+  agentCount: z.number(),
+  tasks: z.array(AgentTaskInfoSchema),
+  events: z.array(TrackingEventSchema).max(200),
+});
+
+/** Top-level agent teams data for a project */
+export const AgentTeamsDataSchema = z.object({
+  projectPath: z.string().max(500),
+  features: z.array(FeatureAgentDataSchema),
+  hasTrackingDir: z.boolean(),
+});
+
+// ─── Session Log Schemas ──────────────────────────────────────────
+
+/** A single parsed line from a JSONL session log */
+export const SessionLogLineSchema = z.object({
+  index: z.number(),
+  raw: z.string(),
+  ts: z.string().optional(),
+  type: z.string().optional(),
+});
+
+/**
+ * A paginated page of session log lines.
+ * cursor is a byte offset into the file; -1 means end of file.
+ * sessionFile is null when no session file was found.
+ */
+export const SessionLogPageSchema = z.object({
+  agentName: z.string(),
+  feature: z.string(),
+  lines: z.array(SessionLogLineSchema),
+  total: z.number(),
+  cursor: z.number(),
+  sessionFile: z.string().nullable(),
+});

--- a/tests/unit/services/agent-orchestrator.test.ts
+++ b/tests/unit/services/agent-orchestrator.test.ts
@@ -437,9 +437,13 @@ describe('AgentOrchestrator', () => {
       const session = await orchestrator.spawn(makeSpawnOptions());
 
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      // Simulate non-Windows so the SIGTERM branch is taken
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       orchestrator.kill(session.id);
 
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
       // Windows calls process.kill(pid) without signal; Unix calls process.kill(pid, 'SIGTERM')
       expect(killSpy.mock.calls.some((args) => args[0] === 99999)).toBe(true);
 
@@ -506,9 +510,13 @@ describe('AgentOrchestrator', () => {
       await orchestrator.spawn(makeSpawnOptions({ taskId: 'dispose-2' }));
 
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      // Simulate non-Windows so the SIGTERM branch is taken
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       orchestrator.dispose();
 
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
       // Should have sent SIGTERM to both (Windows: process.kill(pid), Unix: process.kill(pid, 'SIGTERM'))
       expect(killSpy.mock.calls.some((args) => args[0] === 99999)).toBe(true);
       expect(killSpy.mock.calls.length).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## Summary

- **IPC Contract**: 3 new visualization channels with Zod schemas (getCodebaseGraph, getAgentTeams, getSessionLog)
- **Main Services**: Regex-based codebase graph builder, agent teams reader (tracking/progress JSONL), session log reader with pagination
- **IPC Handlers**: Thin handler wiring + service registry integration
- **Renderer Data Layer**: TanStack Query hooks (auto-refresh agent teams @ 10s), Zustand store for canvas UI state
- **React Flow Canvas**: Interactive zoomable canvas with 5 custom node types (FileGroup, File, FeatureGroup, AgentTask, Guardian), 2 custom edge types (DataFlow, AgentScope with live animation), dagre auto-layout, layer toggles, feature selector
- **Detail Panel**: Slide-in panel showing file imports/exports, agent event timelines, session log viewer
- **Route + Nav**: `/projects/$projectId/visualization` route with "Visual Map" sidebar entry

## Implementation

- 12 tasks across 5 waves, all QA passed
- Codebase Guardian structural check passed (1 trivial fix applied)
- New packages: `@xyflow/react`, `@dagrejs/dagre`, `@types/dagre`

## Test plan

- [x] QA passed all 12 tasks (schema design, service pattern, IPC wiring, component compliance, routing)
- [x] Codebase Guardian passed (7 structural checks)
- [x] Wave fence lint passed per wave
- [x] lint, typecheck, build all pass
- [ ] Manual: navigate to Visual Map from sidebar, verify canvas renders with project data

🤖 Generated with [Claude Code](https://claude.com/claude-code)