### PR TITLE
feat(ui): add ThinkingIndicator component

### DIFF
--- a/src/renderer/features/assistant/components/ResponseStream.tsx
+++ b/src/renderer/features/assistant/components/ResponseStream.tsx
@@ -4,9 +4,11 @@
 
 import { useEffect, useRef } from 'react';
 
-import { AlertCircle, Loader2 } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 
 import { cn } from '@renderer/shared/lib/utils';
+
+import { ThinkingIndicator } from '@ui';
 
 import { useAssistantStore } from '../store';
 
@@ -69,10 +71,7 @@ export function ResponseStream() {
         ))}
 
         {isThinking ? (
-          <div className="text-muted-foreground flex items-center gap-2 text-sm">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span>Thinking...</span>
-          </div>
+          <ThinkingIndicator label="Assistant" size="md" />
         ) : null}
       </div>
     </div>

--- a/src/renderer/features/assistant/components/WidgetMessageArea.tsx
+++ b/src/renderer/features/assistant/components/WidgetMessageArea.tsx
@@ -8,10 +8,12 @@
 
 import { useEffect, useRef } from 'react';
 
-import { AlertCircle, Loader2, MessageSquare } from 'lucide-react';
+import { AlertCircle, MessageSquare } from 'lucide-react';
 
 import { cn } from '@renderer/shared/lib/utils';
 import { useAssistantWidgetStore } from '@renderer/shared/stores/assistant-widget-store';
+
+import { ThinkingIndicator } from '@ui';
 
 import { useSpeechSynthesis } from '@features/voice';
 
@@ -121,10 +123,7 @@ export function WidgetMessageArea() {
         ))}
 
         {isThinking ? (
-          <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            <span>Thinking...</span>
-          </div>
+          <ThinkingIndicator label="Assistant" size="sm" />
         ) : null}
       </div>
     </div>

--- a/src/renderer/features/ideation/components/IdeationPage.tsx
+++ b/src/renderer/features/ideation/components/IdeationPage.tsx
@@ -18,7 +18,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Spinner,
+  ThinkingIndicator,
   Textarea,
 } from '@ui';
 
@@ -145,10 +145,7 @@ export function IdeationPage() {
                   onClick={handleGenerate}
                 >
                   {sendCommand.isPending ? (
-                    <>
-                      <Spinner className="h-4 w-4" />
-                      Generating...
-                    </>
+                    <ThinkingIndicator label="Generating..." size="sm" variant="inline" />
                   ) : (
                     <>
                       <Sparkles className="h-4 w-4" />

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -15,8 +15,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Spinner,
   Textarea,
+  ThinkingIndicator,
 } from '@ui';
 
 import { useSendCommand } from '@features/assistant';
@@ -294,10 +294,7 @@ export function RoadmapPage() {
                 onClick={handleGenerate}
               >
                 {sendCommand.isPending ? (
-                  <>
-                    <Spinner className="h-4 w-4" />
-                    Generating...
-                  </>
+                  <ThinkingIndicator label="Generating..." size="sm" variant="inline" />
                 ) : (
                   <>
                     <Sparkles className="h-4 w-4" />

--- a/src/renderer/shared/components/ui/index.ts
+++ b/src/renderer/shared/components/ui/index.ts
@@ -281,3 +281,6 @@ export type { SectionHeaderProps } from './section-header';
 
 export { InlineAlert, inlineAlertVariants } from './inline-alert';
 export type { InlineAlertProps } from './inline-alert';
+
+export { ThinkingIndicator, thinkingVariants } from './thinking-indicator';
+export type { ThinkingIndicatorProps } from './thinking-indicator';

--- a/src/renderer/shared/components/ui/thinking-indicator.tsx
+++ b/src/renderer/shared/components/ui/thinking-indicator.tsx
@@ -1,0 +1,107 @@
+/**
+ * ThinkingIndicator — Reusable Claude "thinking" animation
+ *
+ * Shows an animated indicator when a Claude session is processing.
+ * Supports multiple sizes and optional session label.
+ *
+ * Usage:
+ *   <ThinkingIndicator />
+ *   <ThinkingIndicator label="Assistant" size="sm" />
+ *   <ThinkingIndicator label="Team Lead 1" size="md" />
+ *   <ThinkingIndicator label="Generating..." size="sm" variant="inline" />
+ */
+
+import { cva } from 'class-variance-authority';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+import type { VariantProps } from 'class-variance-authority';
+
+// ─── Variants ────────────────────────────────────────────
+
+const thinkingVariants = cva('inline-flex items-center', {
+  variants: {
+    size: {
+      xs: 'gap-1 text-[10px]',
+      sm: 'gap-1.5 text-xs',
+      md: 'gap-2 text-sm',
+    },
+    variant: {
+      /** Default: standalone row with label */
+      default: 'text-muted-foreground',
+      /** Inline: subtle, for embedding inside buttons or cells */
+      inline: 'text-muted-foreground/70',
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+    variant: 'default',
+  },
+});
+
+const dotVariants = cva('rounded-full bg-primary', {
+  variants: {
+    size: {
+      xs: 'h-1 w-1',
+      sm: 'h-1.5 w-1.5',
+      md: 'h-2 w-2',
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+});
+
+// ─── Animated Dots ───────────────────────────────────────
+
+function ThinkingDots({ size }: { size?: 'xs' | 'sm' | 'md' }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" role="status">
+      <span
+        className={cn(dotVariants({ size }), 'animate-bounce')}
+        style={{ animationDelay: '0ms', animationDuration: '600ms' }}
+      />
+      <span
+        className={cn(dotVariants({ size }), 'animate-bounce')}
+        style={{ animationDelay: '150ms', animationDuration: '600ms' }}
+      />
+      <span
+        className={cn(dotVariants({ size }), 'animate-bounce')}
+        style={{ animationDelay: '300ms', animationDuration: '600ms' }}
+      />
+    </span>
+  );
+}
+
+// ─── Component ───────────────────────────────────────────
+
+interface ThinkingIndicatorProps
+  extends React.ComponentProps<'span'>,
+    VariantProps<typeof thinkingVariants> {
+  /** Session or feature label (e.g. "Assistant", "Team Lead 1", "Generating...") */
+  label?: string;
+}
+
+function ThinkingIndicator({
+  className,
+  size,
+  variant,
+  label,
+  ...props
+}: ThinkingIndicatorProps) {
+  return (
+    <span
+      aria-label={label ? `${label} is thinking` : 'Thinking'}
+      className={cn(thinkingVariants({ size, variant, className }))}
+      data-slot="thinking-indicator"
+      role="status"
+      {...props}
+    >
+      <ThinkingDots size={size ?? 'sm'} />
+      {label === undefined ? null : <span>{label}</span>}
+    </span>
+  );
+}
+
+export { ThinkingIndicator, thinkingVariants };
+export type { ThinkingIndicatorProps };


### PR DESCRIPTION
## Summary
New `@ui` primitive: `ThinkingIndicator` — bouncing dots animation for Claude session activity.

- **Sizes**: `xs`, `sm`, `md`
- **Variants**: `default` (standalone), `inline` (for embedding in buttons)
- **Label**: optional session name (e.g. "Assistant", "Team Lead 1", "Generating...")
- Replaces ad-hoc `Loader2 + animate-spin` indicators in 4 files

## Usage
```tsx
<ThinkingIndicator />
<ThinkingIndicator label="Assistant" size="sm" />
<ThinkingIndicator label="Generating..." variant="inline" />
```

## Test plan
- [ ] Assistant chat shows bouncing dots when thinking
- [ ] Roadmap "Generate with AI" shows inline dots when pending
- [ ] Ideation "Generate with AI" shows inline dots when pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)