### PR TITLE
feat(workspace): ThinkingIndicator for Primary + Team Lead sessions

### DIFF
--- a/src/renderer/features/ideation/components/IdeationPage.tsx
+++ b/src/renderer/features/ideation/components/IdeationPage.tsx
@@ -18,7 +18,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  ThinkingIndicator,
+  Spinner,
   Textarea,
 } from '@ui';
 
@@ -145,7 +145,10 @@ export function IdeationPage() {
                   onClick={handleGenerate}
                 >
                   {sendCommand.isPending ? (
-                    <ThinkingIndicator label="Generating..." size="sm" variant="inline" />
+                    <>
+                      <Spinner className="h-4 w-4" />
+                      Generating...
+                    </>
                   ) : (
                     <>
                       <Sparkles className="h-4 w-4" />

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -15,8 +15,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Spinner,
   Textarea,
-  ThinkingIndicator,
 } from '@ui';
 
 import { useSendCommand } from '@features/assistant';
@@ -294,7 +294,10 @@ export function RoadmapPage() {
                 onClick={handleGenerate}
               >
                 {sendCommand.isPending ? (
-                  <ThinkingIndicator label="Generating..." size="sm" variant="inline" />
+                  <>
+                    <Spinner className="h-4 w-4" />
+                    Generating...
+                  </>
                 ) : (
                   <>
                     <Sparkles className="h-4 w-4" />

--- a/src/renderer/features/workspace/components/PrimarySessionPanel.tsx
+++ b/src/renderer/features/workspace/components/PrimarySessionPanel.tsx
@@ -16,9 +16,11 @@ import { AgentChatPanel } from '@features/agent-dashboard';
 import { Button } from '@ui/button';
 import { Input } from '@ui/input';
 import { StatusIndicator } from '@ui/status-indicator';
+import { ThinkingIndicator } from '@ui/thinking-indicator';
 import { Text } from '@ui/typography';
 
 import { useWorkspaceSend } from '../api/useWorkspace';
+import { useSessionThinking } from '../hooks/useSessionThinking';
 import { messagesToChatItems } from '../lib/chat-utils';
 import { useWorkspaceStore } from '../store';
 
@@ -44,6 +46,7 @@ export function PrimarySessionPanel({
   status,
 }: PrimarySessionPanelProps) {
   const send = useWorkspaceSend();
+  const isThinking = useSessionThinking(sessionId);
   const draft = useWorkspaceStore((s) => s.inputDrafts[sessionId] ?? '');
   const setDraft = useWorkspaceStore((s) => s.setInputDraft);
   const clearDraft = useWorkspaceStore((s) => s.clearInputDraft);
@@ -100,6 +103,13 @@ export function PrimarySessionPanel({
           <AgentChatPanel messages={chatItems} />
         )}
       </div>
+
+      {/* Thinking indicator */}
+      {isThinking ? (
+        <div className="border-border border-t px-4 py-2">
+          <ThinkingIndicator label={`Primary · ${projectName}`} size="sm" />
+        </div>
+      ) : null}
 
       {/* Input */}
       <div className="border-border flex gap-2 border-t p-3">

--- a/src/renderer/features/workspace/components/TeamLeadPanel.tsx
+++ b/src/renderer/features/workspace/components/TeamLeadPanel.tsx
@@ -16,9 +16,11 @@ import { AgentChatPanel } from '@features/agent-dashboard';
 import { Button } from '@ui/button';
 import { Input } from '@ui/input';
 import { StatusIndicator } from '@ui/status-indicator';
+import { ThinkingIndicator } from '@ui/thinking-indicator';
 import { Text } from '@ui/typography';
 
 import { useStopTeamLead, useWorkspaceSend } from '../api/useWorkspace';
+import { useSessionThinking } from '../hooks/useSessionThinking';
 import { messagesToChatItems } from '../lib/chat-utils';
 import { useWorkspaceStore } from '../store';
 
@@ -42,6 +44,7 @@ export function TeamLeadPanel({ session }: TeamLeadPanelProps) {
 
   const send = useWorkspaceSend();
   const stop = useStopTeamLead(projectId);
+  const isThinking = useSessionThinking(agentSessionId);
   const isCollapsed = useWorkspaceStore((s) => s.teamLeadCollapsed[agentSessionId] ?? false);
   const toggle = useWorkspaceStore((s) => s.toggleTeamLeadCollapsed);
   const draft = useWorkspaceStore((s) => s.inputDrafts[agentSessionId] ?? '');
@@ -118,6 +121,13 @@ export function TeamLeadPanel({ session }: TeamLeadPanelProps) {
               <AgentChatPanel className="max-h-48" messages={chatItems} />
             )}
           </div>
+
+          {/* Thinking indicator */}
+          {isThinking ? (
+            <div className="border-border border-t px-3 py-1.5">
+              <ThinkingIndicator label={label} size="xs" />
+            </div>
+          ) : null}
 
           {/* Input */}
           <div className="border-border flex gap-2 border-t p-2">

--- a/src/renderer/features/workspace/hooks/useSessionThinking.ts
+++ b/src/renderer/features/workspace/hooks/useSessionThinking.ts
@@ -1,0 +1,27 @@
+/**
+ * useSessionThinking — Track whether a specific agent session is "thinking"
+ *
+ * Listens to agent-dashboard statusChanged events and returns true when
+ * the session status is 'running' (Claude is processing).
+ */
+
+import { useCallback, useState } from 'react';
+
+import { useIpcEvent } from '@renderer/shared/hooks';
+
+export function useSessionThinking(sessionId: string | null): boolean {
+  const [isThinking, setIsThinking] = useState(false);
+
+  useIpcEvent(
+    'event:agent-dashboard.statusChanged',
+    useCallback(
+      (payload: { sessionId: string; newStatus: string }) => {
+        if (payload.sessionId !== sessionId) return;
+        setIsThinking(payload.newStatus === 'running');
+      },
+      [sessionId],
+    ),
+  );
+
+  return isThinking;
+}


### PR DESCRIPTION
## Summary
- Add `useSessionThinking` hook — tracks per-session `running` status via `event:agent-dashboard.statusChanged`
- Primary session panel: shows `ThinkingIndicator` with "Primary · {project}" label when processing
- Team Lead panels: shows `ThinkingIndicator` with "Team Lead N" label when processing
- Reverts Generate with AI buttons back to `Spinner` (ThinkingIndicator = chat sessions, Spinner = action buttons)

## Test plan
- [ ] Send message to Primary session → bouncing dots appear with session label
- [ ] Send message to Team Lead → bouncing dots appear
- [ ] Dots disappear when response arrives
- [ ] Generate with AI buttons still show spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)