### PR TITLE
Sprint 1: Core CRUD Completeness (8 tasks, 3 waves)

### DIFF
--- a/drizzle/0012_progress_tasks_schema.sql
+++ b/drizzle/0012_progress_tasks_schema.sql
@@ -1,0 +1,8 @@
+-- Add pr_number, pr_status, jira_url columns to progress_tasks
+-- Drop unused tags and branch columns
+
+ALTER TABLE progress_tasks ADD COLUMN pr_number INTEGER;
+ALTER TABLE progress_tasks ADD COLUMN pr_status TEXT;
+ALTER TABLE progress_tasks ADD COLUMN jira_url TEXT;
+ALTER TABLE progress_tasks DROP COLUMN tags;
+ALTER TABLE progress_tasks DROP COLUMN branch;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1775843200000,
       "tag": "0011_uuid_natural_key_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1775843300000,
+      "tag": "0012_progress_tasks_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/generate-worktree-claude.mjs
+++ b/scripts/generate-worktree-claude.mjs
@@ -211,17 +211,17 @@ const allDocs = [...new Set([...alwaysDocs, ...roleDocs])];
 // ---------------------------------------------------------------------------
 
 const ESSENTIAL_SECTIONS = [
-  'ADC v2 Refactor — Active (P0)',
-  'Verification Requirements — MANDATORY (Non-Skippable)',
-  'ESLint Rules — What You MUST Know',
-  'Import Order (Enforced)',
-  'Design System — Critical Rules',
-  'Critical Pattern: IPC Contract',
-  'Service Pattern',
-  'Feature Module Pattern',
-  'React Component Pattern',
-  'Path Aliases',
-  'State Management',
+  // Updated 2026-04-12 to match post-rewrite CLAUDE.md headings.
+  // The extractor matches from `## <heading>` to the next `## ` or EOF, so
+  // capturing top-level sections also picks up their subsections.
+  'Architecture',
+  'Data Layer',
+  'Feature Slice Design',
+  'Design System Rules',
+  'IPC Conventions',
+  'Key Paths',
+  'Testing',
+  'Communication Standards',
 ];
 
 const extractedSections = ESSENTIAL_SECTIONS

--- a/src/main/features/alerts/alert-handlers.ts
+++ b/src/main/features/alerts/alert-handlers.ts
@@ -14,6 +14,8 @@ export function registerAlertHandlers(router: IpcRouter, service: AlertService):
 
   router.handle(ALERTS.CREATE.ALERT, (data) => Promise.resolve(service.createAlert(data)));
 
+  router.handle(ALERTS.UPDATE.ALERT, (data) => Promise.resolve(service.updateAlert(data)));
+
   router.handle(ALERTS.DISMISS.ALERT, ({ id }) => Promise.resolve(service.dismissAlert(id)));
 
   router.handle(ALERTS.DELETE.ALERT, ({ id }) => Promise.resolve(service.deleteAlert(id)));

--- a/src/main/features/alerts/alert-service.ts
+++ b/src/main/features/alerts/alert-service.ts
@@ -27,6 +27,7 @@ const logger = createScopedLogger('alert-service');
 export interface AlertService {
   createAlert: (data: CreateAlertInput) => Alert;
   listAlerts: (includeExpired?: boolean) => Alert[];
+  updateAlert: (data: UpdateAlertInput) => Alert;
   dismissAlert: (id: string) => Alert;
   deleteAlert: (id: string) => { success: boolean };
   checkAlerts: () => void;
@@ -40,6 +41,14 @@ interface CreateAlertInput {
   message: string;
   triggerAt: string;
   recurring?: RecurringConfig;
+  linkedTo?: AlertLinkedTo;
+}
+
+interface UpdateAlertInput {
+  id: string;
+  message?: string;
+  triggerAt?: string;
+  recurring?: RecurringConfig | null;
   linkedTo?: AlertLinkedTo;
 }
 
@@ -208,6 +217,20 @@ export function createAlertService(deps: {
       }
       const now = new Date();
       return allAlerts.filter((a) => !a.dismissed || new Date(a.triggerAt) > now);
+    },
+
+    updateAlert(data) {
+      const { id, ...fields } = data;
+      const updates: Partial<typeof alerts.$inferInsert> = {};
+      if (fields.message !== undefined) updates.message = fields.message;
+      if (fields.triggerAt !== undefined) updates.triggerAt = fields.triggerAt;
+      if ('recurring' in fields) updates.recurring = fields.recurring ?? null;
+      if (fields.linkedTo !== undefined) updates.linkedTo = fields.linkedTo ?? null;
+
+      db.update(alerts).set(updates).where(eq(alerts.id, id)).run();
+      const updated = findAlert(id);
+      router.emit(ALERTS_EVENTS.ALERT.CHANGED, { alertId: id });
+      return updated;
     },
 
     dismissAlert(id) {

--- a/src/main/features/dashboard/dashboard-handlers.ts
+++ b/src/main/features/dashboard/dashboard-handlers.ts
@@ -14,6 +14,10 @@ export function registerDashboardHandlers(router: IpcRouter, service: DashboardS
     Promise.resolve(service.createCapture(text, id)),
   );
 
+  router.handle(DASHBOARD.UPDATE.CAPTURE, ({ id, text }) =>
+    Promise.resolve(service.updateCapture(id, text)),
+  );
+
   router.handle(DASHBOARD.DELETE.CAPTURE, ({ id }) =>
     Promise.resolve(service.deleteCapture(id)),
   );

--- a/src/main/features/dashboard/dashboard-service.ts
+++ b/src/main/features/dashboard/dashboard-service.ts
@@ -30,6 +30,7 @@ export interface Capture {
 export interface DashboardService {
   listCaptures: () => Capture[];
   createCapture: (text: string, id?: string) => Capture;
+  updateCapture: (id: string, text: string) => Capture;
   deleteCapture: (id: string) => { success: boolean };
 }
 
@@ -83,6 +84,19 @@ export function createDashboardService(deps: {
       db.insert(captures).values(capture).run();
       router.emit(DASHBOARD_EVENTS.CAPTURE.CHANGED, { captureId: capture.id });
       return capture;
+    },
+
+    updateCapture(id, text) {
+      const result = db.update(captures).set({ text }).where(eq(captures.id, id)).run();
+      if (result.changes === 0) {
+        throw new Error(`Capture not found: ${id}`);
+      }
+      const updated = db.select().from(captures).where(eq(captures.id, id)).get();
+      if (!updated) {
+        throw new Error(`Capture not found after update: ${id}`);
+      }
+      router.emit(DASHBOARD_EVENTS.CAPTURE.CHANGED, { captureId: id });
+      return updated;
     },
 
     deleteCapture(id) {

--- a/src/main/features/milestones/milestones-service.ts
+++ b/src/main/features/milestones/milestones-service.ts
@@ -38,6 +38,7 @@ export interface MilestonesService {
       description?: string;
       targetDate?: string;
       status?: MilestoneStatus;
+      tasks?: Array<{ id: string; title: string; completed: boolean }>;
     },
   ) => Milestone;
   deleteMilestone: (id: string) => { success: boolean };
@@ -151,6 +152,7 @@ export function createMilestonesService(deps: {
         ...(updates.description === undefined ? {} : { description: updates.description }),
         ...(updates.targetDate === undefined ? {} : { targetDate: updates.targetDate }),
         ...(updates.status === undefined ? {} : { status: updates.status }),
+        ...(updates.tasks === undefined ? {} : { tasks: updates.tasks }),
         updatedAt: new Date().toISOString(),
       };
       db.update(milestones).set(updated).where(eq(milestones.id, id)).run();

--- a/src/main/features/progress/progress-service.ts
+++ b/src/main/features/progress/progress-service.ts
@@ -255,10 +255,11 @@ async function migrateFromFilesystem(db: AdcDatabase, projectPath: string): Prom
       title: task.title,
       status: task.status,
       priority: task.priority,
-      tags: [],
       jiraKey: task.jiraTicket ?? null,
+      jiraUrl: task.jiraUrl ?? null,
       prUrl: task.prUrl ?? null,
-      branch: null,
+      prNumber: task.prNumber ?? null,
+      prStatus: task.prStatus ?? null,
       lastSessionId: task.lastSessionId ?? null,
       lastAgentName: task.lastAgentName ?? null,
       completedAt: task.completedAt ?? null,
@@ -391,7 +392,10 @@ function rowToTask(
     status: row.status as ProgressStatus,
     priority: row.priority as ProgressPriority,
     jiraTicket: row.jiraKey ?? undefined,
+    jiraUrl: row.jiraUrl ?? undefined,
     prUrl: row.prUrl ?? undefined,
+    prNumber: row.prNumber ?? undefined,
+    prStatus: row.prStatus ?? undefined,
     lastSessionId: row.lastSessionId ?? undefined,
     lastAgentName: row.lastAgentName ?? undefined,
     completedAt: row.completedAt ?? undefined,
@@ -827,7 +831,6 @@ export function createProgressService(
         title,
         status: 'backlog',
         priority,
-        tags: [],
         description: description || null,
         createdAt: now,
         updatedAt: now,
@@ -905,7 +908,10 @@ export function createProgressService(
       if (updates.status !== undefined) dbUpdates.status = updates.status;
       if (updates.priority !== undefined) dbUpdates.priority = updates.priority;
       if (updates.jiraTicket !== undefined) dbUpdates.jiraKey = updates.jiraTicket;
+      if (updates.jiraUrl !== undefined) dbUpdates.jiraUrl = updates.jiraUrl;
       if (updates.prUrl !== undefined) dbUpdates.prUrl = updates.prUrl;
+      if (updates.prNumber !== undefined) dbUpdates.prNumber = updates.prNumber;
+      if (updates.prStatus !== undefined) dbUpdates.prStatus = updates.prStatus;
       if (updates.lastSessionId !== undefined) dbUpdates.lastSessionId = updates.lastSessionId;
       if (updates.lastAgentName !== undefined) dbUpdates.lastAgentName = updates.lastAgentName;
       if (updates.completedAt !== undefined) dbUpdates.completedAt = updates.completedAt;

--- a/src/main/features/progress/schema.ts
+++ b/src/main/features/progress/schema.ts
@@ -1,4 +1,4 @@
-import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 export const progressTasks = sqliteTable('progress_tasks', {
   slug: text('slug').primaryKey(),
@@ -6,10 +6,11 @@ export const progressTasks = sqliteTable('progress_tasks', {
   title: text('title').notNull(),
   status: text('status').notNull(),
   priority: text('priority').notNull().default('medium'),
-  tags: text('tags', { mode: 'json' }).$type<string[]>().notNull().default([]),
   jiraKey: text('jira_key'),
+  jiraUrl: text('jira_url'),
   prUrl: text('pr_url'),
-  branch: text('branch'),
+  prNumber: integer('pr_number'),
+  prStatus: text('pr_status'),
   lastSessionId: text('last_session_id'),
   lastAgentName: text('last_agent_name'),
   completedAt: text('completed_at'),

--- a/src/renderer/features/dashboard/api/useCaptures.ts
+++ b/src/renderer/features/dashboard/api/useCaptures.ts
@@ -52,3 +52,20 @@ export function useCaptureMutations() {
 
   return { createCapture, deleteCapture };
 }
+
+/** Update an existing capture's text */
+export function useUpdateCapture() {
+  const queryClient = useQueryClient();
+  const { onError: toastError } = useMutationErrorToast();
+
+  return useMutation({
+    mutationFn: (data: { id: string; text: string }) =>
+      ipc(DASHBOARD.UPDATE.CAPTURE, data),
+    onSuccess() {
+      void queryClient.invalidateQueries({ queryKey: dashboardKeys.captures() });
+    },
+    onError(err) {
+      toastError('update capture')(err);
+    },
+  });
+}

--- a/src/renderer/features/dashboard/components/QuickCapture.tsx
+++ b/src/renderer/features/dashboard/components/QuickCapture.tsx
@@ -33,10 +33,11 @@ import {
   DropdownMenuTrigger,
   Input,
   SearchInput,
+  Text,
 } from '@ui';
 
-import { useCreateNote } from '@features/personal/notes/api/useNotes';
-import { useCreateProgressTask } from '@features/tasks/api/useProgressMutations';
+import { useCreateNote } from '@features/personal/notes';
+import { useCreateProgressTask } from '@features/tasks';
 
 import { useCaptureMutations, useCaptures, useUpdateCapture } from '../api/useCaptures';
 
@@ -187,13 +188,14 @@ export function QuickCapture() {
                         }
                       />
                     ) : (
-                      <button
-                        className="text-foreground min-w-0 flex-1 cursor-text text-left text-xs"
+                      <Button
+                        className="text-foreground min-w-0 h-auto flex-1 cursor-text justify-start px-0 py-0 text-left text-xs font-normal"
                         type="button"
+                        variant="ghost"
                         onClick={() => handleEditStart(capture.id, capture.text)}
                       >
                         {capture.text}
-                      </button>
+                      </Button>
                     )}
                     <span className="text-muted-foreground shrink-0 text-xs">
                       {formatRelativeTime(capture.createdAt)}
@@ -261,7 +263,7 @@ export function QuickCapture() {
                 ))}
               </ul>
             ) : (
-              <p className="text-muted-foreground text-xs">No captures match your search.</p>
+              <Text size="sm" variant="muted">No captures match your search.</Text>
             )}
 
             {hasMore ? (

--- a/src/renderer/features/dashboard/components/QuickCapture.tsx
+++ b/src/renderer/features/dashboard/components/QuickCapture.tsx
@@ -139,7 +139,7 @@ export function QuickCapture() {
   return (
     <Card>
       <CardContent className="p-4">
-        <p className="text-foreground mb-3 text-sm font-semibold">Quick Capture</p>
+        <Text className="mb-3 font-semibold">Quick Capture</Text>
 
         <div className="flex gap-2">
           <Input

--- a/src/renderer/features/dashboard/components/QuickCapture.tsx
+++ b/src/renderer/features/dashboard/components/QuickCapture.tsx
@@ -2,24 +2,62 @@
  * QuickCapture — Quick text input for ideas, tasks, and notes
  *
  * Persists captures via IPC (dashboard.captures.*) so they survive restarts.
+ * Supports inline editing, search filter, show-all toggle, and per-capture
+ * kebab menu with Convert to Task / Convert to Note / Delete actions.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
-import { Plus, X } from 'lucide-react';
+import { MoreHorizontal, Plus } from 'lucide-react';
 
 import { formatRelativeTime } from '@renderer/shared/lib/utils';
+import { useToastStore } from '@renderer/shared/stores';
 
-import { Button, Card, CardContent, Input } from '@ui';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Button,
+  Card,
+  CardContent,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  SearchInput,
+} from '@ui';
 
-import { useCaptureMutations, useCaptures } from '../api/useCaptures';
+import { useCreateNote } from '@features/personal/notes/api/useNotes';
+import { useCreateProgressTask } from '@features/tasks/api/useProgressMutations';
 
-const MAX_RECENT = 5;
+import { useCaptureMutations, useCaptures, useUpdateCapture } from '../api/useCaptures';
+
+interface EditState {
+  id: string;
+  value: string;
+}
 
 export function QuickCapture() {
   const [inputValue, setInputValue] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showAll, setShowAll] = useState(false);
+  const [editState, setEditState] = useState<EditState | null>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+
   const { data: captures } = useCaptures();
   const { createCapture, deleteCapture } = useCaptureMutations();
+  const updateCapture = useUpdateCapture();
+  const createProgressTask = useCreateProgressTask();
+  const createNote = useCreateNote();
+  const { addToast } = useToastStore();
 
   function handleSubmit() {
     const trimmed = inputValue.trim();
@@ -34,7 +72,68 @@ export function QuickCapture() {
     }
   }
 
-  const recentCaptures = (captures ?? []).slice(0, MAX_RECENT);
+  function handleEditStart(id: string, currentText: string) {
+    setEditState({ id, value: currentText });
+    // Focus the input on next tick after render
+    setTimeout(() => {
+      editInputRef.current?.focus();
+      editInputRef.current?.select();
+    }, 0);
+  }
+
+  function handleEditSave() {
+    if (editState === null) return;
+    const trimmed = editState.value.trim();
+    if (trimmed.length > 0) {
+      updateCapture.mutate({ id: editState.id, text: trimmed });
+    }
+    setEditState(null);
+  }
+
+  function handleEditKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      handleEditSave();
+    } else if (e.key === 'Escape') {
+      setEditState(null);
+    }
+  }
+
+  function handleConvertToTask(text: string, captureId: string) {
+    createProgressTask.mutate(
+      { title: text, description: '' },
+      {
+        onSuccess() {
+          deleteCapture.mutate(captureId);
+          addToast('Converted to task', 'success');
+        },
+      },
+    );
+  }
+
+  function handleConvertToNote(text: string, captureId: string) {
+    createNote.mutate(
+      { title: text, content: '' },
+      {
+        onSuccess() {
+          deleteCapture.mutate(captureId);
+          addToast('Converted to note', 'success');
+        },
+      },
+    );
+  }
+
+  const allCaptures = captures ?? [];
+
+  const filteredCaptures =
+    searchQuery.trim().length > 0
+      ? allCaptures.filter((c) =>
+          c.text.toLowerCase().includes(searchQuery.toLowerCase()),
+        )
+      : allCaptures;
+
+  const LIMIT = 5;
+  const visibleCaptures = showAll ? filteredCaptures : filteredCaptures.slice(0, LIMIT);
+  const hasMore = filteredCaptures.length > LIMIT;
 
   return (
     <Card>
@@ -60,30 +159,125 @@ export function QuickCapture() {
           </Button>
         </div>
 
-        {recentCaptures.length > 0 ? (
-          <ul className="mt-3 space-y-1.5">
-            {recentCaptures.map((capture) => (
-              <li
-                key={capture.id}
-                className="border-border flex items-start gap-2 rounded-md border px-3 py-2"
+        {(allCaptures.length > 0) ? (
+          <div className="mt-3">
+            <SearchInput
+              className="mb-2"
+              placeholder="Filter captures..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+
+            {(visibleCaptures.length > 0) ? (
+              <ul className="space-y-1.5">
+                {visibleCaptures.map((capture) => (
+                  <li
+                    key={capture.id}
+                    className="border-border flex items-start gap-2 rounded-md border px-3 py-2"
+                  >
+                    {(editState !== null && editState.id === capture.id) ? (
+                      <Input
+                        ref={editInputRef}
+                        className="h-6 flex-1 border-0 p-0 text-xs focus-visible:ring-0"
+                        value={editState.value}
+                        onBlur={handleEditSave}
+                        onKeyDown={handleEditKeyDown}
+                        onChange={(e) =>
+                          setEditState({ ...editState, value: e.target.value })
+                        }
+                      />
+                    ) : (
+                      <button
+                        className="text-foreground min-w-0 flex-1 cursor-text text-left text-xs"
+                        type="button"
+                        onClick={() => handleEditStart(capture.id, capture.text)}
+                      >
+                        {capture.text}
+                      </button>
+                    )}
+                    <span className="text-muted-foreground shrink-0 text-xs">
+                      {formatRelativeTime(capture.createdAt)}
+                    </span>
+
+                    <AlertDialog>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            aria-label="Capture actions"
+                            className="text-muted-foreground hover:text-foreground h-auto shrink-0 p-0"
+                            size="icon"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <MoreHorizontal className="h-3 w-3" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              handleConvertToTask(capture.text, capture.id)
+                            }
+                          >
+                            Convert to Task
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              handleConvertToNote(capture.text, capture.id)
+                            }
+                          >
+                            Convert to Note
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive"
+                              onSelect={(e) => e.preventDefault()}
+                            >
+                              Delete
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete capture?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will permanently delete this capture. This action cannot
+                            be undone.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => deleteCapture.mutate(capture.id)}
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted-foreground text-xs">No captures match your search.</p>
+            )}
+
+            {hasMore ? (
+              <Button
+                className="mt-2 w-full"
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={() => setShowAll(!showAll)}
               >
-                <p className="text-foreground min-w-0 flex-1 text-xs">{capture.text}</p>
-                <span className="text-muted-foreground shrink-0 text-xs">
-                  {formatRelativeTime(capture.createdAt)}
-                </span>
-                <Button
-                  aria-label="Remove capture"
-                  className="text-muted-foreground hover:text-foreground h-auto shrink-0 p-0"
-                  size="icon"
-                  type="button"
-                  variant="ghost"
-                  onClick={() => deleteCapture.mutate(capture.id)}
-                >
-                  <X className="h-3 w-3" />
-                </Button>
-              </li>
-            ))}
-          </ul>
+                {showAll
+                  ? 'Show less'
+                  : `Show all (${filteredCaptures.length - LIMIT} more)`}
+              </Button>
+            ) : null}
+          </div>
         ) : null}
       </CardContent>
     </Card>

--- a/src/renderer/features/personal/alerts/api/useAlertMutations.ts
+++ b/src/renderer/features/personal/alerts/api/useAlertMutations.ts
@@ -1,0 +1,24 @@
+/**
+ * Alert mutation hooks
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ALERTS } from '@shared/ipc/misc/alerts.channels';
+import type { UpdateAlertInput } from '@shared/ipc/misc/alerts.contract';
+
+import { ipc } from '@renderer/shared/lib/ipc';
+
+import { alertKeys } from './queryKeys';
+
+/** Update an existing alert (message, triggerAt, recurring, linkedTo) */
+export function useUpdateAlert() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateAlertInput) => ipc(ALERTS.UPDATE.ALERT, data),
+    onSuccess() {
+      void queryClient.invalidateQueries({ queryKey: alertKeys.lists() });
+    },
+  });
+}

--- a/src/renderer/features/personal/alerts/components/AlertEditDialog.tsx
+++ b/src/renderer/features/personal/alerts/components/AlertEditDialog.tsx
@@ -1,0 +1,232 @@
+/**
+ * AlertEditDialog — Edit alert message, triggerAt, recurring config, and linkedTo
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Link } from 'lucide-react';
+
+import type { Alert, RecurringConfig } from '@shared/types';
+
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui';
+
+import { useUpdateAlert } from '../api/useAlertMutations';
+
+interface AlertEditDialogProps {
+  alert: Alert | null;
+  onClose: () => void;
+}
+
+function toDatetimeLocalValue(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return '';
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${String(date.getFullYear())}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  } catch {
+    return '';
+  }
+}
+
+export function AlertEditDialog({ alert, onClose }: AlertEditDialogProps) {
+  const updateAlert = useUpdateAlert();
+
+  const [message, setMessage] = useState('');
+  const [triggerAt, setTriggerAt] = useState('');
+  const [enableRecurring, setEnableRecurring] = useState(false);
+  const [recurringFrequency, setRecurringFrequency] = useState<
+    'daily' | 'weekly' | 'monthly'
+  >('daily');
+  const [recurringTime, setRecurringTime] = useState('09:00');
+
+  // Populate form when alert changes
+  useEffect(() => {
+    if (alert === null) return;
+    setMessage(alert.message);
+    setTriggerAt(toDatetimeLocalValue(alert.triggerAt));
+    if (alert.recurring === undefined) {
+      setEnableRecurring(false);
+      setRecurringFrequency('daily');
+      setRecurringTime('09:00');
+    } else {
+      setEnableRecurring(true);
+      setRecurringFrequency(alert.recurring.frequency);
+      setRecurringTime(alert.recurring.time);
+    }
+  }, [alert]);
+
+  const isOpen = alert !== null;
+
+  function handleSubmit() {
+    if (alert === null) return;
+    const trimmed = message.trim();
+    if (trimmed.length === 0) return;
+
+    const recurring: RecurringConfig | null = enableRecurring
+      ? { frequency: recurringFrequency, time: recurringTime }
+      : null;
+
+    const updatedMessage = trimmed === alert.message ? undefined : trimmed;
+    const updatedTriggerAt =
+      triggerAt.length > 0 ? new Date(triggerAt).toISOString() : undefined;
+
+    updateAlert.mutate(
+      {
+        id: alert.id,
+        message: updatedMessage,
+        triggerAt: updatedTriggerAt,
+        recurring,
+        linkedTo: alert.linkedTo,
+      },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+      },
+    );
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (open) return;
+    onClose();
+  }
+
+  const linkedTo = isOpen ? alert.linkedTo : undefined;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Alert</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* linkedTo badge (read-only display) */}
+          {linkedTo === undefined ? null : (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">Linked to:</span>
+              <Badge variant="secondary">
+                {linkedTo.type}: {linkedTo.id}
+              </Badge>
+            </div>
+          )}
+
+          {/* Message */}
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-alert-message">Message</Label>
+            <Input
+              id="edit-alert-message"
+              placeholder="Alert message"
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </div>
+
+          {/* Trigger At */}
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-alert-trigger-at">Trigger At</Label>
+            <Input
+              id="edit-alert-trigger-at"
+              type="datetime-local"
+              value={triggerAt}
+              onChange={(e) => setTriggerAt(e.target.value)}
+            />
+          </div>
+
+          {/* Recurring toggle */}
+          <div className="space-y-3">
+            <Label
+              className="flex cursor-pointer items-center gap-2"
+              htmlFor="edit-alert-recurring-toggle"
+            >
+              <Checkbox
+                checked={enableRecurring}
+                id="edit-alert-recurring-toggle"
+                onCheckedChange={(checked) => setEnableRecurring(checked === true)}
+              />
+              <span>Recurring</span>
+            </Label>
+
+            {enableRecurring ? (
+              <div className="space-y-3 pl-6">
+                <div className="space-y-1.5">
+                  <Label htmlFor="edit-alert-frequency">Frequency</Label>
+                  <Select
+                    value={recurringFrequency}
+                    onValueChange={(value) =>
+                      setRecurringFrequency(value as 'daily' | 'weekly' | 'monthly')
+                    }
+                  >
+                    <SelectTrigger id="edit-alert-frequency">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="daily">Daily</SelectItem>
+                      <SelectItem value="weekly">Weekly</SelectItem>
+                      <SelectItem value="monthly">Monthly</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="edit-alert-time">Time</Label>
+                  <Input
+                    id="edit-alert-time"
+                    type="time"
+                    value={recurringTime}
+                    onChange={(e) => setRecurringTime(e.target.value)}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={message.trim().length === 0 || updateAlert.isPending}
+            onClick={handleSubmit}
+          >
+            {updateAlert.isPending ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Inline badge to display linkedTo on alert cards */
+interface LinkedToBadgeProps {
+  linkedTo: Alert['linkedTo'];
+}
+
+export function LinkedToBadge({ linkedTo }: LinkedToBadgeProps) {
+  if (linkedTo === undefined) return null;
+
+  return (
+    <Badge className="mt-1 text-xs" variant="outline">
+      <Link className="mr-1 h-2.5 w-2.5" />
+      {linkedTo.type}
+    </Badge>
+  );
+}

--- a/src/renderer/features/personal/alerts/components/AlertsPage.tsx
+++ b/src/renderer/features/personal/alerts/components/AlertsPage.tsx
@@ -2,18 +2,21 @@
  * AlertsPage — List of all alerts with management controls
  */
 
-import { Bell, Check, Clock, Plus, Repeat, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+import { Bell, Check, Clock, Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
 
 import type { Alert } from '@shared/types';
 
 import { cn } from '@renderer/shared/lib/utils';
 
-import { Button, EmptyState, PageContent, PageHeader, PageLayout } from '@ui';
+import { Badge, Button, EmptyState, PageContent, PageHeader, PageLayout } from '@ui';
 
 import { useAlerts, useDeleteAlert, useDismissAlert } from '../api/useAlerts';
 import { useAlertEvents } from '../hooks/useAlertEvents';
 import { useAlertStore } from '../store';
 
+import { AlertEditDialog } from './AlertEditDialog';
 import { CreateAlertModal } from './CreateAlertModal';
 import { RecurringAlerts } from './RecurringAlerts';
 
@@ -59,6 +62,8 @@ export function AlertsPage() {
   const dismissAlert = useDismissAlert();
   const deleteAlert = useDeleteAlert();
   const openCreateModal = useAlertStore((s) => s.openCreateModal);
+
+  const [editingAlert, setEditingAlert] = useState<Alert | null>(null);
 
   const activeAlerts = alerts.filter((a) => !a.dismissed);
   const dismissedAlerts = alerts.filter((a) => a.dismissed);
@@ -117,14 +122,28 @@ export function AlertsPage() {
                   {formatTriggerTime(alert.triggerAt)}
                   {alert.recurring === undefined ? '' : ' (recurring)'}
                 </p>
+                {alert.linkedTo === undefined ? null : (
+                  <Badge className="mt-1 text-xs" variant="outline">
+                    {alert.linkedTo.type}
+                  </Badge>
+                )}
               </div>
 
               <div className="flex shrink-0 gap-1">
+                <Button
+                  aria-label="Edit alert"
+                  className="h-7 w-7 p-1 text-muted-foreground hover:text-foreground"
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setEditingAlert(alert)}
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
                 {alert.dismissed ? null : (
                   <Button
+                    aria-label="Dismiss alert"
                     className="h-7 w-7 p-1 text-muted-foreground hover:text-success"
                     size="icon"
-                    title="Dismiss"
                     variant="ghost"
                     onClick={() => dismissAlert.mutate(alert.id)}
                   >
@@ -132,9 +151,9 @@ export function AlertsPage() {
                   </Button>
                 )}
                 <Button
+                  aria-label="Delete alert"
                   className="h-7 w-7 p-1 text-muted-foreground hover:text-destructive"
                   size="icon"
-                  title="Delete"
                   variant="ghost"
                   onClick={() => deleteAlert.mutate(alert.id)}
                 >
@@ -194,6 +213,10 @@ export function AlertsPage() {
       </PageHeader.Tabs>
 
       <CreateAlertModal />
+      <AlertEditDialog
+        alert={editingAlert}
+        onClose={() => setEditingAlert(null)}
+      />
     </PageLayout>
   );
 }

--- a/src/renderer/features/roadmap/api/useMilestones.ts
+++ b/src/renderer/features/roadmap/api/useMilestones.ts
@@ -49,6 +49,7 @@ export function useUpdateMilestone() {
       description?: string;
       targetDate?: string;
       status?: MilestoneStatus;
+      tasks?: Array<{ id: string; title: string; completed: boolean }>;
     }) => ipc(MILESTONES.UPDATE.MILESTONE, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: milestoneKeys.lists() });

--- a/src/renderer/features/roadmap/components/MilestoneEditDialog.tsx
+++ b/src/renderer/features/roadmap/components/MilestoneEditDialog.tsx
@@ -1,0 +1,379 @@
+/**
+ * MilestoneEditDialog — Edit a milestone's title, description, targetDate, status,
+ * and task items (rename, delete, toggle).
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Pencil, Plus, Square, SquareCheck, Trash2, X } from 'lucide-react';
+
+import type { Milestone, MilestoneStatus, MilestoneTask } from '@shared/types';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  Textarea,
+} from '@ui';
+
+import { useUpdateMilestone } from '../api/useMilestones';
+
+interface MilestoneEditDialogProps {
+  milestone: Milestone | null;
+  onClose: () => void;
+}
+
+export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogProps) {
+  // 1. Hooks
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [targetDate, setTargetDate] = useState('');
+  const [status, setStatus] = useState<MilestoneStatus>('planned');
+  const [tasks, setTasks] = useState<MilestoneTask[]>([]);
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editingTaskTitle, setEditingTaskTitle] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const updateMilestone = useUpdateMilestone();
+
+  // 2. Effects — initialize form from milestone prop
+  useEffect(() => {
+    if (milestone !== null) {
+      setTitle(milestone.title);
+      setDescription(milestone.description);
+      setTargetDate(milestone.targetDate.substring(0, 10));
+      setStatus(milestone.status);
+      setTasks([...milestone.tasks]);
+      setNewTaskTitle('');
+      setEditingTaskId(null);
+      setEditingTaskTitle('');
+      setErrorMessage(null);
+    }
+  }, [milestone]);
+
+  // 3. Derived state
+  const titleIsEmpty = title.trim().length === 0;
+  const targetDateIsEmpty = targetDate.trim().length === 0;
+  const isFormValid = !titleIsEmpty && !targetDateIsEmpty;
+
+  // 4. Task handlers
+  function handleAddTask(): void {
+    if (!newTaskTitle.trim()) return;
+    const newTask: MilestoneTask = {
+      id: crypto.randomUUID(),
+      title: newTaskTitle.trim(),
+      completed: false,
+    };
+    setTasks((prev) => [...prev, newTask]);
+    setNewTaskTitle('');
+  }
+
+  function handleDeleteTask(taskId: string): void {
+    setTasks((prev) => prev.filter((t) => t.id !== taskId));
+  }
+
+  function handleToggleTask(taskId: string): void {
+    setTasks((prev) =>
+      prev.map((t) => (t.id === taskId ? { ...t, completed: !t.completed } : t)),
+    );
+  }
+
+  function handleStartEditTask(task: MilestoneTask): void {
+    setEditingTaskId(task.id);
+    setEditingTaskTitle(task.title);
+  }
+
+  function handleCommitTaskEdit(): void {
+    if (editingTaskId === null) return;
+    if (editingTaskTitle.trim().length === 0) {
+      setEditingTaskId(null);
+      setEditingTaskTitle('');
+      return;
+    }
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === editingTaskId ? { ...t, title: editingTaskTitle.trim() } : t,
+      ),
+    );
+    setEditingTaskId(null);
+    setEditingTaskTitle('');
+  }
+
+  function handleCancelTaskEdit(): void {
+    setEditingTaskId(null);
+    setEditingTaskTitle('');
+  }
+
+  // 5. Submit handler
+  function handleSave(): void {
+    if (milestone === null || !isFormValid) return;
+
+    setErrorMessage(null);
+
+    updateMilestone.mutate(
+      {
+        id: milestone.id,
+        title: title.trim(),
+        description: description.trim(),
+        targetDate: new Date(targetDate).toISOString(),
+        status,
+        tasks,
+      },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (err) => {
+          setErrorMessage(err instanceof Error ? err.message : 'Failed to update milestone');
+        },
+      },
+    );
+  }
+
+  // 6. Render helpers
+  function renderTaskItem(task: MilestoneTask) {
+    const isEditing = editingTaskId === task.id;
+
+    if (isEditing) {
+      return (
+        <div key={task.id} className="flex items-center gap-2 py-0.5">
+          <Input
+            className="h-7 flex-1 text-sm"
+            type="text"
+            value={editingTaskTitle}
+            onChange={(e) => setEditingTaskTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleCommitTaskEdit();
+              if (e.key === 'Escape') handleCancelTaskEdit();
+            }}
+          />
+          <Button
+            aria-label="Confirm task rename"
+            className="h-7 w-7"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={handleCommitTaskEdit}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+          <Button
+            aria-label="Cancel task rename"
+            className="h-7 w-7"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={handleCancelTaskEdit}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        key={task.id}
+        className="flex items-center gap-2 rounded px-1 py-0.5"
+      >
+        <Button
+          aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
+          className="h-6 w-6 shrink-0 p-0"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleToggleTask(task.id)}
+        >
+          {task.completed ? (
+            <SquareCheck className="text-primary h-4 w-4" />
+          ) : (
+            <Square className="text-muted-foreground h-4 w-4" />
+          )}
+        </Button>
+        <span
+          className={cn(
+            'flex-1 truncate text-sm',
+            task.completed && 'text-muted-foreground line-through',
+          )}
+        >
+          {task.title}
+        </span>
+        <Button
+          aria-label="Edit task title"
+          className="h-6 w-6 shrink-0 p-0 opacity-0 group-hover:opacity-100"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleStartEditTask(task)}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button
+          aria-label="Delete task"
+          className="text-muted-foreground hover:text-destructive h-6 w-6 shrink-0 p-0"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleDeleteTask(task.id)}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Dialog open={milestone !== null} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-3">
+            <Pencil className="text-primary h-5 w-5" />
+            Edit Milestone
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Title */}
+          <div>
+            <Label htmlFor="edit-milestone-title">
+              Title <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              aria-required="true"
+              className="mt-1"
+              id="edit-milestone-title"
+              placeholder="Milestone title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <Label htmlFor="edit-milestone-description">Description</Label>
+            <Textarea
+              className="mt-1 resize-none"
+              id="edit-milestone-description"
+              placeholder="Optional description"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          {/* Target Date */}
+          <div>
+            <Label htmlFor="edit-milestone-date">
+              Target Date <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              aria-required="true"
+              className="mt-1"
+              id="edit-milestone-date"
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+            />
+          </div>
+
+          {/* Status */}
+          <div>
+            <Label htmlFor="edit-milestone-status">Status</Label>
+            <Select value={status} onValueChange={(v) => setStatus(v as MilestoneStatus)}>
+              <SelectTrigger className="mt-1" id="edit-milestone-status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="planned">Planned</SelectItem>
+                <SelectItem value="in-progress">In Progress</SelectItem>
+                <SelectItem value="completed">Completed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Tasks */}
+          <div>
+            <Label>Tasks</Label>
+            <div className="border-border mt-1 space-y-0.5 rounded-md border p-2">
+              {(tasks.length) > 0 ? (
+                <div className="group mb-2 space-y-0.5">
+                  {tasks.map((task) => renderTaskItem(task))}
+                </div>
+              ) : null}
+
+              {/* Add new task */}
+              <div className="flex gap-2">
+                <Input
+                  className="h-7 flex-1 text-sm"
+                  placeholder="Add a task..."
+                  type="text"
+                  value={newTaskTitle}
+                  onChange={(e) => setNewTaskTitle(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAddTask();
+                  }}
+                />
+                <Button
+                  aria-label="Add task"
+                  className="h-7 w-7"
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                  onClick={handleAddTask}
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Error message */}
+        {errorMessage === null ? null : (
+          <div className="rounded-md bg-destructive/10 p-3">
+            <p className="text-destructive text-sm">{errorMessage}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!isFormValid || updateMilestone.isPending}
+            type="button"
+            onClick={handleSave}
+          >
+            {updateMilestone.isPending ? (
+              <>
+                <Spinner size="sm" />
+                Saving...
+              </>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/features/roadmap/components/MilestoneEditDialog.tsx
+++ b/src/renderer/features/roadmap/components/MilestoneEditDialog.tsx
@@ -5,11 +5,9 @@
 
 import { useEffect, useState } from 'react';
 
-import { Pencil, Plus, Square, SquareCheck, Trash2, X } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 
 import type { Milestone, MilestoneStatus, MilestoneTask } from '@shared/types';
-
-import { cn } from '@renderer/shared/lib/utils';
 
 import {
   Button,
@@ -26,10 +24,13 @@ import {
   SelectTrigger,
   SelectValue,
   Spinner,
+  Text,
   Textarea,
 } from '@ui';
 
 import { useUpdateMilestone } from '../api/useMilestones';
+
+import { MilestoneTaskListEditor } from './MilestoneTaskListEditor';
 
 interface MilestoneEditDialogProps {
   milestone: Milestone | null;
@@ -43,9 +44,6 @@ export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogP
   const [targetDate, setTargetDate] = useState('');
   const [status, setStatus] = useState<MilestoneStatus>('planned');
   const [tasks, setTasks] = useState<MilestoneTask[]>([]);
-  const [newTaskTitle, setNewTaskTitle] = useState('');
-  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
-  const [editingTaskTitle, setEditingTaskTitle] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const updateMilestone = useUpdateMilestone();
@@ -58,9 +56,6 @@ export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogP
       setTargetDate(milestone.targetDate.substring(0, 10));
       setStatus(milestone.status);
       setTasks([...milestone.tasks]);
-      setNewTaskTitle('');
-      setEditingTaskId(null);
-      setEditingTaskTitle('');
       setErrorMessage(null);
     }
   }, [milestone]);
@@ -70,55 +65,7 @@ export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogP
   const targetDateIsEmpty = targetDate.trim().length === 0;
   const isFormValid = !titleIsEmpty && !targetDateIsEmpty;
 
-  // 4. Task handlers
-  function handleAddTask(): void {
-    if (!newTaskTitle.trim()) return;
-    const newTask: MilestoneTask = {
-      id: crypto.randomUUID(),
-      title: newTaskTitle.trim(),
-      completed: false,
-    };
-    setTasks((prev) => [...prev, newTask]);
-    setNewTaskTitle('');
-  }
-
-  function handleDeleteTask(taskId: string): void {
-    setTasks((prev) => prev.filter((t) => t.id !== taskId));
-  }
-
-  function handleToggleTask(taskId: string): void {
-    setTasks((prev) =>
-      prev.map((t) => (t.id === taskId ? { ...t, completed: !t.completed } : t)),
-    );
-  }
-
-  function handleStartEditTask(task: MilestoneTask): void {
-    setEditingTaskId(task.id);
-    setEditingTaskTitle(task.title);
-  }
-
-  function handleCommitTaskEdit(): void {
-    if (editingTaskId === null) return;
-    if (editingTaskTitle.trim().length === 0) {
-      setEditingTaskId(null);
-      setEditingTaskTitle('');
-      return;
-    }
-    setTasks((prev) =>
-      prev.map((t) =>
-        t.id === editingTaskId ? { ...t, title: editingTaskTitle.trim() } : t,
-      ),
-    );
-    setEditingTaskId(null);
-    setEditingTaskTitle('');
-  }
-
-  function handleCancelTaskEdit(): void {
-    setEditingTaskId(null);
-    setEditingTaskTitle('');
-  }
-
-  // 5. Submit handler
+  // 4. Submit handler
   function handleSave(): void {
     if (milestone === null || !isFormValid) return;
 
@@ -141,98 +88,6 @@ export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogP
           setErrorMessage(err instanceof Error ? err.message : 'Failed to update milestone');
         },
       },
-    );
-  }
-
-  // 6. Render helpers
-  function renderTaskItem(task: MilestoneTask) {
-    const isEditing = editingTaskId === task.id;
-
-    if (isEditing) {
-      return (
-        <div key={task.id} className="flex items-center gap-2 py-0.5">
-          <Input
-            className="h-7 flex-1 text-sm"
-            type="text"
-            value={editingTaskTitle}
-            onChange={(e) => setEditingTaskTitle(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleCommitTaskEdit();
-              if (e.key === 'Escape') handleCancelTaskEdit();
-            }}
-          />
-          <Button
-            aria-label="Confirm task rename"
-            className="h-7 w-7"
-            size="icon"
-            type="button"
-            variant="ghost"
-            onClick={handleCommitTaskEdit}
-          >
-            <Plus className="h-3 w-3" />
-          </Button>
-          <Button
-            aria-label="Cancel task rename"
-            className="h-7 w-7"
-            size="icon"
-            type="button"
-            variant="ghost"
-            onClick={handleCancelTaskEdit}
-          >
-            <X className="h-3 w-3" />
-          </Button>
-        </div>
-      );
-    }
-
-    return (
-      <div
-        key={task.id}
-        className="flex items-center gap-2 rounded px-1 py-0.5"
-      >
-        <Button
-          aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
-          className="h-6 w-6 shrink-0 p-0"
-          size="icon"
-          type="button"
-          variant="ghost"
-          onClick={() => handleToggleTask(task.id)}
-        >
-          {task.completed ? (
-            <SquareCheck className="text-primary h-4 w-4" />
-          ) : (
-            <Square className="text-muted-foreground h-4 w-4" />
-          )}
-        </Button>
-        <span
-          className={cn(
-            'flex-1 truncate text-sm',
-            task.completed && 'text-muted-foreground line-through',
-          )}
-        >
-          {task.title}
-        </span>
-        <Button
-          aria-label="Edit task title"
-          className="h-6 w-6 shrink-0 p-0 opacity-0 group-hover:opacity-100"
-          size="icon"
-          type="button"
-          variant="ghost"
-          onClick={() => handleStartEditTask(task)}
-        >
-          <Pencil className="h-3 w-3" />
-        </Button>
-        <Button
-          aria-label="Delete task"
-          className="text-muted-foreground hover:text-destructive h-6 w-6 shrink-0 p-0"
-          size="icon"
-          type="button"
-          variant="ghost"
-          onClick={() => handleDeleteTask(task.id)}
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
-      </div>
     );
   }
 
@@ -307,46 +162,13 @@ export function MilestoneEditDialog({ milestone, onClose }: MilestoneEditDialogP
           </div>
 
           {/* Tasks */}
-          <div>
-            <Label>Tasks</Label>
-            <div className="border-border mt-1 space-y-0.5 rounded-md border p-2">
-              {(tasks.length) > 0 ? (
-                <div className="group mb-2 space-y-0.5">
-                  {tasks.map((task) => renderTaskItem(task))}
-                </div>
-              ) : null}
-
-              {/* Add new task */}
-              <div className="flex gap-2">
-                <Input
-                  className="h-7 flex-1 text-sm"
-                  placeholder="Add a task..."
-                  type="text"
-                  value={newTaskTitle}
-                  onChange={(e) => setNewTaskTitle(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleAddTask();
-                  }}
-                />
-                <Button
-                  aria-label="Add task"
-                  className="h-7 w-7"
-                  size="icon"
-                  type="button"
-                  variant="ghost"
-                  onClick={handleAddTask}
-                >
-                  <Plus className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          </div>
+          <MilestoneTaskListEditor tasks={tasks} onChange={setTasks} />
         </div>
 
         {/* Error message */}
         {errorMessage === null ? null : (
           <div className="rounded-md bg-destructive/10 p-3">
-            <p className="text-destructive text-sm">{errorMessage}</p>
+            <Text size="md" variant="error">{errorMessage}</Text>
           </div>
         )}
 

--- a/src/renderer/features/roadmap/components/MilestoneTaskListEditor.tsx
+++ b/src/renderer/features/roadmap/components/MilestoneTaskListEditor.tsx
@@ -1,0 +1,194 @@
+/**
+ * MilestoneTaskListEditor — Manage the task checklist within a milestone.
+ * Handles add / rename / toggle / delete operations on MilestoneTask items.
+ */
+
+import { useState } from 'react';
+
+import { Pencil, Plus, Square, SquareCheck, Trash2, X } from 'lucide-react';
+
+import type { MilestoneTask } from '@shared/types';
+
+import { cn } from '@renderer/shared/lib/utils';
+
+import { Button, Input, Label } from '@ui';
+
+interface MilestoneTaskListEditorProps {
+  tasks: MilestoneTask[];
+  onChange: (tasks: MilestoneTask[]) => void;
+}
+
+export function MilestoneTaskListEditor({ tasks, onChange }: MilestoneTaskListEditorProps) {
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editingTaskTitle, setEditingTaskTitle] = useState('');
+
+  function handleAddTask(): void {
+    if (newTaskTitle.trim().length === 0) return;
+    const newTask: MilestoneTask = {
+      id: crypto.randomUUID(),
+      title: newTaskTitle.trim(),
+      completed: false,
+    };
+    onChange([...tasks, newTask]);
+    setNewTaskTitle('');
+  }
+
+  function handleDeleteTask(taskId: string): void {
+    onChange(tasks.filter((t) => t.id !== taskId));
+  }
+
+  function handleToggleTask(taskId: string): void {
+    onChange(tasks.map((t) => (t.id === taskId ? { ...t, completed: !t.completed } : t)));
+  }
+
+  function handleStartEditTask(task: MilestoneTask): void {
+    setEditingTaskId(task.id);
+    setEditingTaskTitle(task.title);
+  }
+
+  function handleCommitTaskEdit(): void {
+    if (editingTaskId === null) return;
+    if (editingTaskTitle.trim().length > 0) {
+      onChange(
+        tasks.map((t) =>
+          t.id === editingTaskId ? { ...t, title: editingTaskTitle.trim() } : t,
+        ),
+      );
+    }
+    setEditingTaskId(null);
+    setEditingTaskTitle('');
+  }
+
+  function handleCancelTaskEdit(): void {
+    setEditingTaskId(null);
+    setEditingTaskTitle('');
+  }
+
+  function renderTaskItem(task: MilestoneTask) {
+    const isEditing = editingTaskId === task.id;
+
+    if (isEditing) {
+      return (
+        <div key={task.id} className="flex items-center gap-2 py-0.5">
+          <Input
+            className="h-7 flex-1 text-sm"
+            type="text"
+            value={editingTaskTitle}
+            onChange={(e) => setEditingTaskTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleCommitTaskEdit();
+              if (e.key === 'Escape') handleCancelTaskEdit();
+            }}
+          />
+          <Button
+            aria-label="Confirm task rename"
+            className="h-7 w-7"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={handleCommitTaskEdit}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+          <Button
+            aria-label="Cancel task rename"
+            className="h-7 w-7"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={handleCancelTaskEdit}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        key={task.id}
+        className="flex items-center gap-2 rounded px-1 py-0.5"
+      >
+        <Button
+          aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
+          className="h-6 w-6 shrink-0 p-0"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleToggleTask(task.id)}
+        >
+          {task.completed ? (
+            <SquareCheck className="text-primary h-4 w-4" />
+          ) : (
+            <Square className="text-muted-foreground h-4 w-4" />
+          )}
+        </Button>
+        <span
+          className={cn(
+            'flex-1 truncate text-sm',
+            task.completed && 'text-muted-foreground line-through',
+          )}
+        >
+          {task.title}
+        </span>
+        <Button
+          aria-label="Edit task title"
+          className="h-6 w-6 shrink-0 p-0 opacity-0 group-hover:opacity-100"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleStartEditTask(task)}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button
+          aria-label="Delete task"
+          className="text-muted-foreground hover:text-destructive h-6 w-6 shrink-0 p-0"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={() => handleDeleteTask(task.id)}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Label>Tasks</Label>
+      <div className="border-border mt-1 space-y-0.5 rounded-md border p-2">
+        {(tasks.length > 0) ? (
+          <div className="group mb-2 space-y-0.5">
+            {tasks.map((task) => renderTaskItem(task))}
+          </div>
+        ) : null}
+
+        <div className="flex gap-2">
+          <Input
+            className="h-7 flex-1 text-sm"
+            placeholder="Add a task..."
+            type="text"
+            value={newTaskTitle}
+            onChange={(e) => setNewTaskTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAddTask();
+            }}
+          />
+          <Button
+            aria-label="Add task"
+            className="h-7 w-7"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={handleAddTask}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { CheckCircle2, Circle, Clock, Map, Plus, Sparkles, Square, SquareCheck, Trash2 } from 'lucide-react';
+import { CheckCircle2, Circle, Clock, Map, Pencil, Plus, Sparkles, Square, SquareCheck, Trash2 } from 'lucide-react';
 
 import type { Milestone, MilestoneStatus } from '@shared/types';
 
@@ -21,7 +21,6 @@ import {
 
 import { useSendCommand } from '@features/assistant';
 
-
 import {
   useAddMilestoneTask,
   useCreateMilestone,
@@ -31,6 +30,8 @@ import {
   useUpdateMilestone,
 } from '../api/useMilestones';
 import { useMilestoneEvents } from '../hooks/useMilestoneEvents';
+
+import { MilestoneEditDialog } from './MilestoneEditDialog';
 
 const STATUS_CONFIG: Record<
   MilestoneStatus,
@@ -74,10 +75,12 @@ function computeProgress(milestone: Milestone): number {
 function MilestoneCard({
   milestone,
   onDelete,
+  onEdit,
   onStatusChange,
 }: {
   milestone: Milestone;
   onDelete: (id: string) => void;
+  onEdit: (milestone: Milestone) => void;
   onStatusChange: (id: string, status: MilestoneStatus) => void;
 }) {
   const [newTaskTitle, setNewTaskTitle] = useState('');
@@ -115,6 +118,17 @@ function MilestoneCard({
             </SelectContent>
           </Select>
           <Button
+            aria-label="Edit milestone"
+            className="text-muted-foreground hover:text-foreground"
+            size="icon"
+            type="button"
+            variant="ghost"
+            onClick={() => onEdit(milestone)}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            aria-label="Delete milestone"
             className="text-muted-foreground hover:text-destructive"
             size="icon"
             type="button"
@@ -210,6 +224,7 @@ export function RoadmapPage() {
   const [formDate, setFormDate] = useState('');
   const [showGenerate, setShowGenerate] = useState(false);
   const [generatePrompt, setGeneratePrompt] = useState(DEFAULT_GENERATE_PROMPT);
+  const [editingMilestone, setEditingMilestone] = useState<Milestone | null>(null);
 
   const sendCommand = useSendCommand();
   const openWidget = useAssistantWidgetStore((s) => s.open);
@@ -390,6 +405,7 @@ export function RoadmapPage() {
                   key={milestone.id}
                   milestone={milestone}
                   onDelete={(id) => deleteMilestone.mutate(id)}
+                  onEdit={(m) => setEditingMilestone(m)}
                   onStatusChange={(id, status) => updateMilestone.mutate({ id, status })}
                 />
               ))}
@@ -406,6 +422,12 @@ export function RoadmapPage() {
             </p>
           </div>
         ) : null}
+
+      {/* Edit dialog */}
+      <MilestoneEditDialog
+        milestone={editingMilestone}
+        onClose={() => setEditingMilestone(null)}
+      />
     </div>
   );
 }

--- a/src/renderer/features/tasks/components/EditProgressTaskDialog.tsx
+++ b/src/renderer/features/tasks/components/EditProgressTaskDialog.tsx
@@ -1,0 +1,215 @@
+/**
+ * EditProgressTaskDialog — Edit title, description, priority, and status
+ * for an existing progress task.
+ *
+ * Opened from:
+ *   - ProgressTaskGrid row action column (edit icon button)
+ *   - ProgressTaskDetailRow footer edit button
+ */
+
+import { useState } from 'react';
+
+import type { ProgressPriority, ProgressStatus, ProgressTask } from '@shared/types/progress';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  Text,
+  Textarea,
+} from '@ui';
+
+import { useUpdateProgressTask } from '../api/useProgressMutations';
+
+// ── Constants ───────────────────────────────────────────────
+
+const PRIORITY_OPTIONS: Array<{ value: ProgressPriority; label: string }> = [
+  { value: 'low', label: 'Low' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+const STATUS_OPTIONS: Array<{ value: ProgressStatus; label: string }> = [
+  { value: 'backlog', label: 'Backlog' },
+  { value: 'researching', label: 'Researching' },
+  { value: 'research_done', label: 'Research Done' },
+  { value: 'planning', label: 'Planning' },
+  { value: 'plan_ready', label: 'Plan Ready' },
+  { value: 'executing', label: 'Executing' },
+  { value: 'review', label: 'Review' },
+  { value: 'done', label: 'Done' },
+  { value: 'error', label: 'Error' },
+];
+
+// ── Props ───────────────────────────────────────────────────
+
+interface EditProgressTaskDialogProps {
+  task: ProgressTask;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ── Component ───────────────────────────────────────────────
+
+export function EditProgressTaskDialog({ task, open, onOpenChange }: EditProgressTaskDialogProps) {
+  const updateTask = useUpdateProgressTask();
+
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description);
+  const [priority, setPriority] = useState<ProgressPriority>(task.priority);
+  const [status, setStatus] = useState<ProgressStatus>(task.status);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      // Reset form to task values on close
+      setTitle(task.title);
+      setDescription(task.description);
+      setPriority(task.priority);
+      setStatus(task.status);
+      setError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (title.trim().length === 0) {
+      setError('Title is required.');
+      return;
+    }
+
+    setError(null);
+
+    const updates: {
+      title?: string;
+      description?: string;
+      priority?: ProgressPriority;
+      status?: ProgressStatus;
+    } = {};
+
+    if (title.trim() !== task.title) updates.title = title.trim();
+    if (description.trim() !== task.description) updates.description = description.trim();
+    if (priority !== task.priority) updates.priority = priority;
+    if (status !== task.status) updates.status = status;
+
+    try {
+      await updateTask.mutateAsync({ slug: task.slug, updates });
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update task.');
+    }
+  }
+
+  const isSubmitting = updateTask.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Task</DialogTitle>
+          <DialogDescription>
+            Update title, description, priority, and status for this task.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-4" id="edit-task-form" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-task-title">Title</Label>
+            <Input
+              id="edit-task-title"
+              placeholder="Task title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-task-description">Description</Label>
+            <Textarea
+              id="edit-task-description"
+              placeholder="Short description (optional)"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-task-priority">Priority</Label>
+            <Select
+              value={priority}
+              onValueChange={(v) => setPriority(v as ProgressPriority)}
+            >
+              <SelectTrigger id="edit-task-priority">
+                <SelectValue placeholder="Select priority" />
+              </SelectTrigger>
+              <SelectContent>
+                {PRIORITY_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-task-status">Status</Label>
+            <Select
+              value={status}
+              onValueChange={(v) => setStatus(v as ProgressStatus)}
+            >
+              <SelectTrigger id="edit-task-status">
+                <SelectValue placeholder="Select status" />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error === null ? null : (
+            <Text className="text-destructive text-sm">{error}</Text>
+          )}
+        </form>
+
+        <DialogFooter>
+          <Button
+            disabled={isSubmitting}
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={isSubmitting || title.trim().length === 0}
+            form="edit-task-form"
+            type="submit"
+          >
+            {isSubmitting ? <Spinner className="mr-2" size="sm" /> : null}
+            Save Changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/features/tasks/components/LinkJiraDialog.tsx
+++ b/src/renderer/features/tasks/components/LinkJiraDialog.tsx
@@ -1,0 +1,154 @@
+/**
+ * LinkJiraDialog — Associate a Jira ticket with a progress task.
+ *
+ * Fields: jiraTicket (text) + jiraUrl (URL, validated on submit).
+ * Calls useUpdateProgressTask() on submit.
+ */
+
+import { useState } from 'react';
+
+import type { ProgressTask } from '@shared/types/progress';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Spinner,
+  Text,
+} from '@ui';
+
+import { useUpdateProgressTask } from '../api/useProgressMutations';
+
+// ── Props ────────────────────────────────────────────────────
+
+interface LinkJiraDialogProps {
+  task: ProgressTask;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function isValidUrl(value: string): boolean {
+  if (value.trim().length === 0) return true; // optional
+  try {
+    new URL(value.trim());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Component ────────────────────────────────────────────────
+
+export function LinkJiraDialog({ task, open, onOpenChange }: LinkJiraDialogProps) {
+  const updateTask = useUpdateProgressTask();
+
+  const [jiraTicket, setJiraTicket] = useState(task.jiraTicket ?? '');
+  const [jiraUrl, setJiraUrl] = useState(task.jiraUrl ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setJiraTicket(task.jiraTicket ?? '');
+      setJiraUrl(task.jiraUrl ?? '');
+      setError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (jiraTicket.trim().length === 0) {
+      setError('Ticket ID is required.');
+      return;
+    }
+
+    if (!isValidUrl(jiraUrl)) {
+      setError('Jira URL must be a valid URL (e.g. https://jira.example.com/browse/ABC-123).');
+      return;
+    }
+
+    setError(null);
+
+    try {
+      await updateTask.mutateAsync({
+        slug: task.slug,
+        updates: {
+          jiraTicket: jiraTicket.trim(),
+          jiraUrl: jiraUrl.trim() || undefined,
+        },
+      });
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link Jira ticket.');
+    }
+  }
+
+  const isSubmitting = updateTask.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Link Jira Ticket</DialogTitle>
+          <DialogDescription>
+            Associate a Jira ticket with this task. The ticket ID will appear as a badge.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-4" id="link-jira-form" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="jira-ticket-id">Ticket ID</Label>
+            <Input
+              id="jira-ticket-id"
+              placeholder="ABC-123"
+              value={jiraTicket}
+              onChange={(e) => setJiraTicket(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="jira-ticket-url">Jira URL (optional)</Label>
+            <Input
+              id="jira-ticket-url"
+              placeholder="https://jira.example.com/browse/ABC-123"
+              type="url"
+              value={jiraUrl}
+              onChange={(e) => setJiraUrl(e.target.value)}
+            />
+          </div>
+
+          {error === null ? null : (
+            <Text className="text-destructive text-sm">{error}</Text>
+          )}
+        </form>
+
+        <DialogFooter>
+          <Button
+            disabled={isSubmitting}
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={isSubmitting || jiraTicket.trim().length === 0}
+            form="link-jira-form"
+            type="submit"
+          >
+            {isSubmitting ? <Spinner className="mr-2" size="sm" /> : null}
+            Link Ticket
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/features/tasks/components/LinkPrDialog.tsx
+++ b/src/renderer/features/tasks/components/LinkPrDialog.tsx
@@ -1,0 +1,158 @@
+/**
+ * LinkPrDialog — Associate a GitHub PR with a progress task.
+ *
+ * Input: prUrl (text). On submit, parses a GitHub pull request URL to
+ * derive prNumber via regex. Sets prStatus to "open" as default.
+ * Calls useUpdateProgressTask() on submit.
+ */
+
+import { useState } from 'react';
+
+import type { ProgressTask } from '@shared/types/progress';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Spinner,
+  Text,
+} from '@ui';
+
+import { useUpdateProgressTask } from '../api/useProgressMutations';
+
+// ── Props ────────────────────────────────────────────────────
+
+interface LinkPrDialogProps {
+  task: ProgressTask;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const GITHUB_PR_REGEX = /github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/;
+
+function parsePrNumber(url: string): number | undefined {
+  const match = GITHUB_PR_REGEX.exec(url.trim());
+  if (match?.[1] === undefined) return undefined;
+  const parsed = Number.parseInt(match[1], 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+// ── Component ────────────────────────────────────────────────
+
+export function LinkPrDialog({ task, open, onOpenChange }: LinkPrDialogProps) {
+  const updateTask = useUpdateProgressTask();
+
+  const [prUrl, setPrUrl] = useState(task.prUrl ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setPrUrl(task.prUrl ?? '');
+      setError(null);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const trimmedUrl = prUrl.trim();
+
+    if (trimmedUrl.length === 0) {
+      setError('PR URL is required.');
+      return;
+    }
+
+    // Validate URL syntax
+    try {
+      new URL(trimmedUrl);
+    } catch {
+      setError('Must be a valid URL (e.g. https://github.com/owner/repo/pull/42).');
+      return;
+    }
+
+    const prNumber = parsePrNumber(trimmedUrl);
+
+    setError(null);
+
+    try {
+      await updateTask.mutateAsync({
+        slug: task.slug,
+        updates: {
+          prUrl: trimmedUrl,
+          prNumber,
+          prStatus: task.prStatus ?? 'open',
+        },
+      });
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link PR.');
+    }
+  }
+
+  const isSubmitting = updateTask.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Link Pull Request</DialogTitle>
+          <DialogDescription>
+            Associate a GitHub pull request URL with this task. The PR number will be derived
+            automatically from GitHub URLs.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-4" id="link-pr-form" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="pr-url">PR URL</Label>
+            <Input
+              id="pr-url"
+              placeholder="https://github.com/owner/repo/pull/42"
+              type="url"
+              value={prUrl}
+              onChange={(e) => setPrUrl(e.target.value)}
+            />
+            {prUrl.trim().length > 0 ? (
+              <Text className="text-muted-foreground text-xs">
+                {parsePrNumber(prUrl) === undefined
+                  ? 'PR number could not be parsed from this URL'
+                  : `PR #${String(parsePrNumber(prUrl))} detected`}
+              </Text>
+            ) : null}
+          </div>
+
+          {error === null ? null : (
+            <Text className="text-destructive text-sm">{error}</Text>
+          )}
+        </form>
+
+        <DialogFooter>
+          <Button
+            disabled={isSubmitting}
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={isSubmitting || prUrl.trim().length === 0}
+            form="link-pr-form"
+            type="submit"
+          >
+            {isSubmitting ? <Spinner className="mr-2" size="sm" /> : null}
+            Link PR
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/features/tasks/components/detail/ProgressTaskDetailRow.tsx
+++ b/src/renderer/features/tasks/components/detail/ProgressTaskDetailRow.tsx
@@ -51,6 +51,8 @@ import {
   useStartResearch,
 } from '../../api/useProgressMutations';
 import { EditProgressTaskDialog } from '../EditProgressTaskDialog';
+import { LinkJiraDialog } from '../LinkJiraDialog';
+import { LinkPrDialog } from '../LinkPrDialog';
 
 import { extractSummaryBlock } from './summary-block-parser';
 import { TeamActivityPanel } from './TeamActivityPanel';
@@ -507,6 +509,8 @@ export function ProgressTaskDetailRow({ task }: ProgressTaskDetailRowProps) {
   }, [allTasks]);
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [linkJiraOpen, setLinkJiraOpen] = useState(false);
+  const [linkPrOpen, setLinkPrOpen] = useState(false);
 
   type PipelineTab = 'research' | 'plan' | 'execute';
   const [activeTab, setActiveTab] = useState<PipelineTab>(() => {
@@ -710,16 +714,22 @@ export function ProgressTaskDetailRow({ task }: ProgressTaskDetailRowProps) {
                 </a>
               </Button>
             ) : (
-              <Button disabled size="sm" variant="outline">Link Ticket</Button>
+              <Button size="sm" variant="outline" onClick={() => { setLinkJiraOpen(true); }}>
+                Link Ticket
+              </Button>
             )}
             {hasPr ? (
               <Button asChild size="sm" variant="outline">
                 <a href={task.prUrl} rel="noreferrer" target="_blank">
-                  <Text size="sm">#{task.prNumber}</Text>
+                  <Badge size="sm" variant={prStatusVariant(task.prStatus)}>
+                    #{task.prNumber}
+                  </Badge>
                 </a>
               </Button>
             ) : (
-              <Button disabled size="sm" variant="outline">Link PR</Button>
+              <Button size="sm" variant="outline" onClick={() => { setLinkPrOpen(true); }}>
+                Link PR
+              </Button>
             )}
 
             <Separator className="h-4" orientation="vertical" />
@@ -748,6 +758,18 @@ export function ProgressTaskDetailRow({ task }: ProgressTaskDetailRowProps) {
         open={editDialogOpen}
         task={task}
         onOpenChange={setEditDialogOpen}
+      />
+
+      <LinkJiraDialog
+        open={linkJiraOpen}
+        task={task}
+        onOpenChange={setLinkJiraOpen}
+      />
+
+      <LinkPrDialog
+        open={linkPrOpen}
+        task={task}
+        onOpenChange={setLinkPrOpen}
       />
     </div>
   );

--- a/src/renderer/features/tasks/components/detail/ProgressTaskDetailRow.tsx
+++ b/src/renderer/features/tasks/components/detail/ProgressTaskDetailRow.tsx
@@ -10,7 +10,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Pencil } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -50,6 +50,7 @@ import {
   useSpinUpTeam,
   useStartResearch,
 } from '../../api/useProgressMutations';
+import { EditProgressTaskDialog } from '../EditProgressTaskDialog';
 
 import { extractSummaryBlock } from './summary-block-parser';
 import { TeamActivityPanel } from './TeamActivityPanel';
@@ -505,6 +506,8 @@ export function ProgressTaskDetailRow({ task }: ProgressTaskDetailRowProps) {
     return sessions;
   }, [allTasks]);
 
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+
   type PipelineTab = 'research' | 'plan' | 'execute';
   const [activeTab, setActiveTab] = useState<PipelineTab>(() => {
     if (task.hasTeamTasks) return 'execute';
@@ -727,10 +730,25 @@ export function ProgressTaskDetailRow({ task }: ProgressTaskDetailRowProps) {
             <Button className="text-destructive hover:text-destructive" disabled={isActionActive} size="sm" variant="outline" onClick={() => { archiveTaskMutation.mutate({ slug: task.slug }); }}>
               Archive
             </Button>
+
+            <Button
+              aria-label="Edit task"
+              size="sm"
+              variant="outline"
+              onClick={() => { setEditDialogOpen(true); }}
+            >
+              <Pencil className="mr-1.5 h-3.5 w-3.5" />
+              Edit
+            </Button>
           </Flex>
         </Flex>
       </div>
 
+      <EditProgressTaskDialog
+        open={editDialogOpen}
+        task={task}
+        onOpenChange={setEditDialogOpen}
+      />
     </div>
   );
 }

--- a/src/renderer/features/tasks/components/grid/ProgressTaskGrid.tsx
+++ b/src/renderer/features/tasks/components/grid/ProgressTaskGrid.tsx
@@ -14,7 +14,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Play, Plus } from 'lucide-react';
+import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Pencil, Play, Plus } from 'lucide-react';
 
 import type { ProgressPriority, ProgressStatus, ProgressTask } from '@shared/types/progress';
 
@@ -62,6 +62,7 @@ import {
   useRunWorkflow,
 } from '../../api/useProgressMutations';
 import { ProgressTaskDetailRow } from '../detail/ProgressTaskDetailRow';
+import { EditProgressTaskDialog } from '../EditProgressTaskDialog';
 
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
 
@@ -343,6 +344,7 @@ function createProgressColumns(
   activeSessions: Record<string, { sessionId: string; action: string }>,
   onRunWorkflow: (slug: string) => void,
   onArchive: (slug: string) => void,
+  onEdit: (task: ProgressTask) => void,
 ): Array<ColumnDef<ProgressTask>> {
   return [
     {
@@ -605,6 +607,30 @@ function createProgressColumns(
         );
       },
     },
+    {
+      id: 'edit',
+      header: '',
+      size: 40,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label="Edit task"
+              size="icon-xs"
+              variant="ghost"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(row.original);
+              }}
+            >
+              <Pencil />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit task</TooltipContent>
+        </Tooltip>
+      ),
+    },
   ];
 }
 
@@ -639,6 +665,7 @@ export function ProgressTaskGrid() {
   const [searchText, setSearchText] = useState('');
   const [statusFilter, setStatusFilter] = useState<ProgressStatus | 'all'>('all');
   const [newTaskDialogOpen, setNewTaskDialogOpen] = useState(false);
+  const [editTask, setEditTask] = useState<ProgressTask | null>(null);
   const [runWorkflowError, setRunWorkflowError] = useState<string | null>(null);
 
   // Derived
@@ -688,6 +715,10 @@ export function ProgressTaskGrid() {
     archiveTaskMutation.mutate({ slug });
   }
 
+  function handleInlineEdit(task: ProgressTask) {
+    setEditTask(task);
+  }
+
   // Filtered data
   const filteredTasks = useMemo(() => {
     let filtered = tasks;
@@ -719,6 +750,7 @@ export function ProgressTaskGrid() {
         activeSessions,
         handleInlineRunWorkflow,
         handleInlineArchive,
+        handleInlineEdit,
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [expandedSlugs, selectedSlugs, activeSessions],
@@ -871,6 +903,17 @@ export function ProgressTaskGrid() {
           await createTaskMutation.mutateAsync({ slug, title, description, priority });
         }}
       />
+
+      {/* Edit Task Dialog */}
+      {editTask === null ? null : (
+        <EditProgressTaskDialog
+          open
+          task={editTask}
+          onOpenChange={(open) => {
+            if (!open) setEditTask(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/features/tasks/index.ts
+++ b/src/renderer/features/tasks/index.ts
@@ -4,6 +4,7 @@
 
 // API hooks (only barrel-export hooks with external consumers)
 export { useAllTasks } from './api/useTasks';
+export { useCreateProgressTask } from './api/useProgressMutations';
 export { taskKeys } from './api/queryKeys';
 
 // Events

--- a/src/shared/ipc/dashboard/channels.ts
+++ b/src/shared/ipc/dashboard/channels.ts
@@ -3,6 +3,7 @@ import { domain, events } from '../channel-builder';
 export const DASHBOARD = domain('dashboard', {
   LIST: ['captures'],
   CREATE: ['capture'],
+  UPDATE: ['capture'],
   DELETE: ['capture'],
 });
 

--- a/src/shared/ipc/dashboard/contract.ts
+++ b/src/shared/ipc/dashboard/contract.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { SuccessResponseSchema } from '../common/schemas';
 
 import { DASHBOARD, DASHBOARD_EVENTS } from './channels';
-import { CaptureSchema } from './schemas';
+import { CaptureSchema, UpdateCaptureInputSchema } from './schemas';
 
 export const dashboardInvoke = {
   [DASHBOARD.LIST.CAPTURES]: {
@@ -18,6 +18,10 @@ export const dashboardInvoke = {
   },
   [DASHBOARD.CREATE.CAPTURE]: {
     input: z.object({ id: z.string().optional(), text: z.string() }),
+    output: CaptureSchema,
+  },
+  [DASHBOARD.UPDATE.CAPTURE]: {
+    input: UpdateCaptureInputSchema,
     output: CaptureSchema,
   },
   [DASHBOARD.DELETE.CAPTURE]: {

--- a/src/shared/ipc/dashboard/schemas.ts
+++ b/src/shared/ipc/dashboard/schemas.ts
@@ -11,3 +11,8 @@ export const CaptureSchema = z.object({
   text: z.string(),
   createdAt: z.string(),
 });
+
+export const UpdateCaptureInputSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+});

--- a/src/shared/ipc/misc/alerts.channels.ts
+++ b/src/shared/ipc/misc/alerts.channels.ts
@@ -3,6 +3,7 @@ import { domain, events } from '../channel-builder';
 export const ALERTS = domain('alerts', {
   LIST: ['all'],
   CREATE: ['alert'],
+  UPDATE: ['alert'],
   DISMISS: ['alert'],
   DELETE: ['alert'],
 });

--- a/src/shared/ipc/misc/alerts.contract.ts
+++ b/src/shared/ipc/misc/alerts.contract.ts
@@ -34,6 +34,15 @@ export const AlertSchema = z.object({
   createdAt: z.string(),
 });
 
+export type UpdateAlertInput = z.infer<typeof UpdateAlertInputSchema>;
+export const UpdateAlertInputSchema = z.object({
+  id: z.string(),
+  message: z.string().optional(),
+  triggerAt: z.string().optional(),
+  recurring: RecurringConfigSchema.nullable().optional(),
+  linkedTo: AlertLinkedToSchema.optional(),
+});
+
 export const alertsInvoke = {
   [ALERTS.LIST.ALL]: {
     input: z.object({ includeExpired: z.boolean().optional() }),
@@ -48,6 +57,10 @@ export const alertsInvoke = {
       recurring: RecurringConfigSchema.optional(),
       linkedTo: AlertLinkedToSchema.optional(),
     }),
+    output: AlertSchema,
+  },
+  [ALERTS.UPDATE.ALERT]: {
+    input: UpdateAlertInputSchema,
     output: AlertSchema,
   },
   [ALERTS.DISMISS.ALERT]: {

--- a/src/shared/ipc/misc/milestones.contract.ts
+++ b/src/shared/ipc/misc/milestones.contract.ts
@@ -52,6 +52,7 @@ export const milestonesInvoke = {
       description: z.string().optional(),
       targetDate: z.string().optional(),
       status: MilestoneStatusSchema.optional(),
+      tasks: z.array(MilestoneTaskSchema).optional(),
     }),
     output: MilestoneSchema,
   },


### PR DESCRIPTION
## Summary

Closes the biggest user-facing CRUD gaps across Progress Tasks, Milestones, Alerts, and Captures — all edit dialogs, search/convert/edit on captures, Jira/PR linking on tasks, and the backing IPC + schema changes needed to persist them.

Part of the Gap Closure multi-sprint plan (`docs/superpowers/plans/2026-04-11-gap-closure-multi-sprint.md`).

## Tasks

**Wave 1 — Backend (e34ae84, b2bd244, 3fa7e4b):**
- T1 — Progress Tasks: add pr_number / pr_status / jira_url columns, drop unused tags + branch, migration 0012
- T2 — Alerts: add UPDATE.ALERT IPC channel + updateAlert service
- T3 — Captures: add UPDATE.CAPTURE IPC channel + updateCapture service

**Wave 2 — UI (e21b85e, 92e17de, 83967d8, 611bf25):**
- T4 — Progress Tasks: EditProgressTaskDialog (title/description/priority/status)
- T5 — Milestones: MilestoneEditDialog + MilestoneTaskListEditor (task list CRUD), backward-compat tasks array on UPDATE.MILESTONE contract
- T6 — Alerts: AlertEditDialog + useUpdateAlert + linkedTo badge display
- T7 — Captures: QuickCapture inline edit + search + convert-to-task/note + show-all toggle

**Wave 3 — Dependent UI (e708204):**
- T8 — Progress Tasks: LinkJiraDialog + LinkPrDialog + badge rendering

**Guardian fixes (463ce6d, ec02ce0):**
- Barrel export for useCreateProgressTask
- Cross-feature imports routed through barrels
- Raw HTML → @ui primitives (3 sites)
- MilestoneEditDialog split to respect 300-line limit

## Changes

| Area | Files |
|------|-------|
| Migrations | drizzle/0012_progress_tasks_schema.sql, drizzle/meta/_journal.json |
| Main schema + service | src/main/features/progress/schema.ts, progress-service.ts, src/main/features/alerts/alert-service.ts, alert-handlers.ts, src/main/features/dashboard/dashboard-service.ts, dashboard-handlers.ts, src/main/features/milestones/milestones-service.ts |
| IPC contracts | src/shared/ipc/misc/alerts.channels.ts, alerts.contract.ts, src/shared/ipc/dashboard/channels.ts, schemas.ts, contract.ts, src/shared/ipc/misc/milestones.contract.ts |
| Renderer (new) | EditProgressTaskDialog, LinkJiraDialog, LinkPrDialog, MilestoneEditDialog, MilestoneTaskListEditor, AlertEditDialog, useAlertMutations |
| Renderer (modified) | ProgressTaskGrid, ProgressTaskDetailRow, RoadmapPage, AlertsPage, QuickCapture, useCaptures, useMilestones, tasks/index.ts |

## Test plan

- [x] QA passed all 8 tasks (wave-scoped review × 3 waves)
- [x] Typecheck + incremental lint pass across all work branches and merged state
- [x] Codebase Guardian passed (R2 after one fix round — all @ui discipline + cross-feature imports + file-size limits)
- [ ] Manual: verify create/edit flows for each entity in dev build
- [ ] Manual: verify Jira/PR link round-trip survives app restart (proves T1 schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)