### PR TITLE
Sprint 3: search, filter, bulk operations

### DIFF
--- a/src/renderer/features/agent-dashboard/components/AgentDashboardPage.tsx
+++ b/src/renderer/features/agent-dashboard/components/AgentDashboardPage.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 
-import { Bot } from 'lucide-react';
+import { Bot, Search } from 'lucide-react';
 
 import type {
   AgentDashboardFilters,
@@ -16,8 +16,11 @@ import type {
   AgentLayoutMode,
   AgentPanelState,
   AgentSession,
+  AgentSessionType,
+  AgentStatus,
 } from '@shared/types/agent-dashboard';
 
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
 import { cn } from '@renderer/shared/lib/utils';
 
 import {
@@ -31,6 +34,11 @@ import {
   Label,
   PageHeader,
   PageLayout,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Separator,
   Spinner,
   Tabs,
@@ -52,6 +60,32 @@ import { RunningWorkflowsPanel } from './RunningWorkflowsPanel';
 import { TemplateEditorPanel } from './TemplateEditorPanel';
 import { TemplateListPanel } from './TemplateListPanel';
 
+// ─── Constants ─────────────────────────────────────────────
+
+const SESSION_TYPE_OPTIONS: Array<{ value: AgentSessionType | 'all'; label: string }> = [
+  { value: 'all', label: 'All types' },
+  { value: 'project-owner', label: 'Project owner' },
+  { value: 'team-lead', label: 'Team lead' },
+  { value: 'teammate', label: 'Teammate' },
+];
+
+const STATUS_OPTIONS: Array<{ value: AgentStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'running', label: 'Running' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'idle', label: 'Idle' },
+];
+
+// ─── Local filter state ─────────────────────────────────────
+
+interface SessionFilterState {
+  sessionType: AgentSessionType | 'all';
+  status: AgentStatus | 'all';
+  teamName: string;
+  search: string;
+}
+
 // ─── Props ─────────────────────────────────────────────────
 
 interface AgentDashboardPageProps {
@@ -71,6 +105,15 @@ export function AgentDashboardPage({
     layoutMode: 'single',
     filters: {},
   });
+
+  const [sessionFilters, setSessionFilters] = useState<SessionFilterState>({
+    sessionType: 'all',
+    status: 'all',
+    teamName: 'all',
+    search: '',
+  });
+
+  const debouncedSearch = useDebounce(sessionFilters.search, 250);
 
   const activeMainTab = useAgentDashboardStore((s) => s.activeMainTab);
   const setActiveMainTab = useAgentDashboardStore((s) => s.setActiveMainTab);
@@ -118,58 +161,178 @@ export function AgentDashboardPage({
     setAgentUiState((prev) => ({ ...prev, popupAgentId: agentId }));
   }, []);
 
+  // ─── Team name options ────────────────────────────────
+
+  const teamNameOptions = useMemo(() => {
+    const names = Array.from(
+      new Set(agents.map((a) => a.teamName).filter((n): n is string => n !== undefined && n !== ''))
+    );
+    return names;
+  }, [agents]);
+
   // ─── Filtered Agents ──────────────────────────────────
 
   const filteredAgents = useMemo(() => {
     let result = agents;
+
+    // Existing IPC-backed filters
     if (agentUiState.filters.projectId !== undefined) {
       result = result.filter((a) => a.projectId === agentUiState.filters.projectId);
     }
     if (agentUiState.filters.status !== undefined) {
       result = result.filter((a) => a.status === agentUiState.filters.status);
     }
+
+    // New client-side filters
+    if (sessionFilters.sessionType !== 'all') {
+      result = result.filter((a) => a.type === sessionFilters.sessionType);
+    }
+    if (sessionFilters.status !== 'all') {
+      result = result.filter((a) => a.status === sessionFilters.status);
+    }
+    if (sessionFilters.teamName !== 'all') {
+      result = result.filter((a) => a.teamName === sessionFilters.teamName);
+    }
+    if (debouncedSearch.trim().length > 0) {
+      const query = debouncedSearch.trim().toLowerCase();
+      result = result.filter((a) => a.name.toLowerCase().includes(query));
+    }
+
     return result;
-  }, [agents, agentUiState.filters]);
+  }, [agents, agentUiState.filters, sessionFilters, debouncedSearch]);
 
   const popupAgent = useMemo(
     () => agents.find((a) => a.id === agentUiState.popupAgentId),
     [agents, agentUiState.popupAgentId],
   );
 
+  // ─── Agents tab filter bar ────────────────────────────
+
+  function renderSessionFilterBar() {
+    return (
+      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+        {/* Session type filter */}
+        <Select
+          value={sessionFilters.sessionType}
+          onValueChange={(v) =>
+            setSessionFilters((prev) => ({
+              ...prev,
+              sessionType: v as AgentSessionType | 'all',
+            }))
+          }
+        >
+          <SelectTrigger aria-label="Filter by session type" className="w-40">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            {SESSION_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Status filter */}
+        <Select
+          value={sessionFilters.status}
+          onValueChange={(v) =>
+            setSessionFilters((prev) => ({
+              ...prev,
+              status: v as AgentStatus | 'all',
+            }))
+          }
+        >
+          <SelectTrigger aria-label="Filter by status" className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Team name filter */}
+        <Select
+          value={sessionFilters.teamName}
+          onValueChange={(v) =>
+            setSessionFilters((prev) => ({ ...prev, teamName: v }))
+          }
+        >
+          <SelectTrigger aria-label="Filter by team" className="w-40">
+            <SelectValue placeholder="All teams" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All teams</SelectItem>
+            {teamNameOptions.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Search by session name */}
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            aria-label="Search sessions by name"
+            className="pl-9"
+            placeholder="Search sessions..."
+            type="text"
+            value={sessionFilters.search}
+            onChange={(e) =>
+              setSessionFilters((prev) => ({ ...prev, search: e.target.value }))
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+
   // ─── Agents tab empty state ───────────────────────────
 
   function renderAgentsContent() {
     if (agents.length === 0) {
       return (
-        <div className="flex h-full flex-col items-center justify-center">
-          <Bot className="mb-4 h-12 w-12 text-muted-foreground" />
-          <Text className="text-lg font-medium text-foreground">No agents running</Text>
-          <Text className="mt-1 text-sm text-muted-foreground">
-            Start a session to see agent activity here
-          </Text>
-        </div>
+        <>
+          {renderSessionFilterBar()}
+          <div className="flex flex-1 flex-col items-center justify-center">
+            <Bot className="mb-4 h-12 w-12 text-muted-foreground" />
+            <Text className="text-lg font-medium text-foreground">No agents running</Text>
+            <Text className="mt-1 text-sm text-muted-foreground">
+              Start a session to see agent activity here
+            </Text>
+          </div>
+        </>
       );
     }
 
     return (
       <>
-        {agentUiState.layoutMode === 'single' ? (
-          <AgentLayoutSingle
-            agents={filteredAgents}
-            className="h-full"
-            expandedAgentId={agentUiState.expandedAgentId}
-            onPanelStateChange={handlePanelStateChange}
-            onViewAgent={handleViewAgent}
-          />
-        ) : (
-          <AgentLayoutGrid
-            agents={filteredAgents}
-            className="h-full"
-            expandedAgentId={agentUiState.expandedAgentId}
-            onPanelStateChange={handlePanelStateChange}
-            onViewAgent={handleViewAgent}
-          />
-        )}
+        {renderSessionFilterBar()}
+        <div className="min-h-0 flex-1 p-4">
+          {agentUiState.layoutMode === 'single' ? (
+            <AgentLayoutSingle
+              agents={filteredAgents}
+              className="h-full"
+              expandedAgentId={agentUiState.expandedAgentId}
+              onPanelStateChange={handlePanelStateChange}
+              onViewAgent={handleViewAgent}
+            />
+          ) : (
+            <AgentLayoutGrid
+              agents={filteredAgents}
+              className="h-full"
+              expandedAgentId={agentUiState.expandedAgentId}
+              onPanelStateChange={handlePanelStateChange}
+              onViewAgent={handleViewAgent}
+            />
+          )}
+        </div>
         {popupAgent === undefined ? null : (
           <AgentPanelPopup
             agent={popupAgent}
@@ -216,7 +379,7 @@ export function AgentDashboardPage({
             </TabsList>
           </div>
 
-          <TabsContent className="min-h-0 flex-1 p-4" value="agents">
+          <TabsContent className="flex min-h-0 flex-1 flex-col" value="agents">
             {renderAgentsContent()}
           </TabsContent>
 

--- a/src/renderer/features/my-work/components/MyWorkPage.tsx
+++ b/src/renderer/features/my-work/components/MyWorkPage.tsx
@@ -2,20 +2,26 @@
  * MyWorkPage -- Cross-project task view
  *
  * Displays all progress tasks from SQLite, optionally grouped by team name.
- * Includes status filter for quick access to tasks by state.
+ * Includes status filter, search input, sort dropdown, priority/Jira/PR badges,
+ * and clickable rows that navigate to the project tasks view.
  */
 
 import { useMemo, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { Briefcase, Filter, RefreshCw, Users } from 'lucide-react';
+import { useNavigate } from '@tanstack/react-router';
+import { Briefcase, ExternalLink, Filter, RefreshCw, Users } from 'lucide-react';
 
+import { ROUTE_PATTERNS } from '@shared/constants';
 import { PROGRESS_EVENTS } from '@shared/ipc/progress/channels';
-import type { ProgressStatus, ProgressTask } from '@shared/types/progress';
+import type { ProgressPriority, ProgressStatus, ProgressTask } from '@shared/types/progress';
 
 import { useIpcEvent } from '@renderer/shared/hooks';
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
+import { useLayoutStore } from '@renderer/shared/stores/layout-store';
 
 import {
+  Badge,
   Button,
   Card,
   CardContent,
@@ -24,6 +30,7 @@ import {
   PageContent,
   PageHeader,
   PageLayout,
+  SearchInput,
   Select,
   SelectContent,
   SelectItem,
@@ -31,13 +38,19 @@ import {
   SelectValue,
   Separator,
   StatusBadge,
+  Text,
 } from '@ui';
-
 
 import { myWorkKeys } from '../api/queryKeys';
 import { useAllTasks } from '../api/useMyWork';
 
 import type { StatusBadgeProps } from '@ui';
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const EXTERNAL_LINK_FEATURES = 'noopener,noreferrer';
 
 /* ------------------------------------------------------------------ */
 /*  Status filter                                                      */
@@ -58,6 +71,58 @@ const STATUS_OPTIONS: Array<{ value: StatusFilter; label: string }> = [
   { value: 'archived', label: 'Archived' },
   { value: 'error', label: 'Error' },
 ];
+
+/* ------------------------------------------------------------------ */
+/*  Sort options                                                        */
+/* ------------------------------------------------------------------ */
+
+type SortField = 'priority' | 'updatedAt' | 'status';
+
+const SORT_OPTIONS: Array<{ value: SortField; label: string }> = [
+  { value: 'priority', label: 'Priority' },
+  { value: 'updatedAt', label: 'Updated At' },
+  { value: 'status', label: 'Status' },
+];
+
+const PRIORITY_ORDER: Record<ProgressPriority, number> = {
+  urgent: 0,
+  high: 1,
+  normal: 2,
+  low: 3,
+};
+
+const STATUS_ORDER: Record<ProgressStatus, number> = {
+  error: 0,
+  executing: 1,
+  review: 2,
+  planning: 3,
+  plan_ready: 4,
+  researching: 5,
+  research_done: 6,
+  backlog: 7,
+  done: 8,
+  archived: 9,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Priority badge config                                              */
+/* ------------------------------------------------------------------ */
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'warning' | 'info' | 'success' | 'error';
+
+const PRIORITY_BADGE_VARIANTS: Record<ProgressPriority, BadgeVariant> = {
+  low: 'outline',
+  normal: 'secondary',
+  high: 'info',
+  urgent: 'destructive',
+};
+
+const PRIORITY_LABELS: Record<ProgressPriority, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  urgent: 'Urgent',
+};
 
 /* ------------------------------------------------------------------ */
 /*  ProgressStatus badge config                                        */
@@ -101,7 +166,7 @@ function ProgressStatusBadge({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Grouping by team name                                              */
+/*  Filtering, sorting, grouping                                       */
 /* ------------------------------------------------------------------ */
 
 interface TasksByTeam {
@@ -128,9 +193,31 @@ function groupTasksByTeam(tasks: ProgressTask[]): TasksByTeam[] {
   return result;
 }
 
-function filterTasks(tasks: ProgressTask[], status: StatusFilter): ProgressTask[] {
+function filterByStatus(tasks: ProgressTask[], status: StatusFilter): ProgressTask[] {
   if (status === 'all') return tasks;
   return tasks.filter((t) => t.status === status);
+}
+
+function filterBySearch(tasks: ProgressTask[], query: string): ProgressTask[] {
+  if (query.trim().length === 0) return tasks;
+  const lower = query.toLowerCase();
+  return tasks.filter(
+    (t) =>
+      t.title.toLowerCase().includes(lower) ||
+      t.description.toLowerCase().includes(lower),
+  );
+}
+
+function sortTasks(tasks: ProgressTask[], field: SortField): ProgressTask[] {
+  const sorted = [...tasks];
+  if (field === 'priority') {
+    sorted.sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
+  } else if (field === 'updatedAt') {
+    sorted.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  } else {
+    sorted.sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+  }
+  return sorted;
 }
 
 function getTaskCountLabel(count: number): string {
@@ -144,7 +231,7 @@ function getTaskCountLabel(count: number): string {
 function MyWorkEmptyState({ hasFilter }: { hasFilter: boolean }) {
   const title = hasFilter ? 'No tasks match filter' : 'No tasks yet';
   const description = hasFilter
-    ? 'Try selecting a different status filter to see more tasks.'
+    ? 'Try selecting a different status filter or changing your search to see more tasks.'
     : 'Tasks will appear here once you create them. Add a project and create tasks to get started.';
 
   return (
@@ -157,7 +244,129 @@ function MyWorkEmptyState({ hasFilter }: { hasFilter: boolean }) {
   );
 }
 
-function TeamGroup({ group }: { group: TasksByTeam }) {
+interface TaskRowProps {
+  task: ProgressTask;
+  onNavigate: (task: ProgressTask) => void;
+}
+
+function TaskRow({ task, onNavigate }: TaskRowProps) {
+  const hasJira = task.jiraTicket !== undefined && task.jiraUrl !== undefined;
+  const hasPr = task.prNumber !== undefined && task.prUrl !== undefined;
+
+  function handleClick() {
+    onNavigate(task);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onNavigate(task);
+    }
+  }
+
+  function handleJiraClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    const url = task.jiraUrl;
+    if (url !== undefined) {
+      window.open(url, '_blank', EXTERNAL_LINK_FEATURES);
+    }
+  }
+
+  function handlePrClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    const url = task.prUrl;
+    if (url !== undefined) {
+      window.open(url, '_blank', EXTERNAL_LINK_FEATURES);
+    }
+  }
+
+  function handleJiraKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      const url = task.jiraUrl;
+      if (url !== undefined) {
+        window.open(url, '_blank', EXTERNAL_LINK_FEATURES);
+      }
+    }
+  }
+
+  function handlePrKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      const url = task.prUrl;
+      if (url !== undefined) {
+        window.open(url, '_blank', EXTERNAL_LINK_FEATURES);
+      }
+    }
+  }
+
+  return (
+    <div
+      className="hover:bg-accent/50 cursor-pointer px-4 py-3 transition-colors"
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Text className="truncate font-medium" size="sm">
+            {task.title}
+          </Text>
+          <Badge size="sm" variant={PRIORITY_BADGE_VARIANTS[task.priority]}>
+            {PRIORITY_LABELS[task.priority]}
+          </Badge>
+          {hasJira ? (
+            <div
+              aria-label={`Open Jira ticket ${task.jiraTicket ?? ''}`}
+              className="flex cursor-pointer items-center gap-1"
+              role="button"
+              tabIndex={0}
+              onClick={handleJiraClick}
+              onKeyDown={handleJiraKeyDown}
+            >
+              <Badge size="sm" variant="info">
+                {task.jiraTicket}
+              </Badge>
+              <ExternalLink className="text-muted-foreground h-3 w-3 shrink-0" />
+            </div>
+          ) : null}
+          {hasPr ? (
+            <div
+              aria-label={`Open PR #${task.prNumber ?? ''}`}
+              className="flex cursor-pointer items-center gap-1"
+              role="button"
+              tabIndex={0}
+              onClick={handlePrClick}
+              onKeyDown={handlePrKeyDown}
+            >
+              <Badge size="sm" variant="secondary">
+                PR #{task.prNumber}
+              </Badge>
+              <ExternalLink className="text-muted-foreground h-3 w-3 shrink-0" />
+            </div>
+          ) : null}
+        </div>
+        <ProgressStatusBadge status={task.status} />
+      </div>
+      {task.description.length > 0 ? (
+        <Text className="line-clamp-2 text-xs" variant="muted">
+          {task.description}
+        </Text>
+      ) : null}
+    </div>
+  );
+}
+
+function TeamGroup({
+  group,
+  onNavigate,
+}: {
+  group: TasksByTeam;
+  onNavigate: (task: ProgressTask) => void;
+}) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center gap-2 py-3">
@@ -169,18 +378,11 @@ function TeamGroup({ group }: { group: TasksByTeam }) {
       <CardContent className="p-0">
         <div className="divide-border divide-y">
           {group.tasks.map((task) => (
-            <div
+            <TaskRow
               key={task.slug}
-              className="px-4 py-3"
-            >
-              <div className="mb-1 flex items-start justify-between gap-2">
-                <span className="text-foreground text-sm font-medium">{task.title}</span>
-                <ProgressStatusBadge status={task.status} />
-              </div>
-              {task.description ? (
-                <p className="text-muted-foreground line-clamp-2 text-xs">{task.description}</p>
-              ) : null}
-            </div>
+              task={task}
+              onNavigate={onNavigate}
+            />
           ))}
         </div>
       </CardContent>
@@ -211,12 +413,14 @@ function TaskListContent({
   taskGroups,
   hasFilter,
   onRetry,
+  onNavigate,
 }: {
   isLoading: boolean;
   isError: boolean;
   taskGroups: TasksByTeam[];
   hasFilter: boolean;
   onRetry: () => void;
+  onNavigate: (task: ProgressTask) => void;
 }) {
   if (isError) {
     return <ErrorState onRetry={onRetry} />;
@@ -240,6 +444,7 @@ function TaskListContent({
         <TeamGroup
           key={group.teamName}
           group={group}
+          onNavigate={onNavigate}
         />
       ))}
     </div>
@@ -252,7 +457,15 @@ function TaskListContent({
 
 export function MyWorkPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const activeProjectId = useLayoutStore((s) => s.activeProjectId);
+
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortField, setSortField] = useState<SortField>('priority');
+
+  const debouncedSearch = useDebounce(searchQuery, 250);
+
   const { data: tasks, isLoading: tasksLoading, isError: tasksError } = useAllTasks();
 
   // Invalidate task list on progress events
@@ -270,17 +483,28 @@ export function MyWorkPage() {
     void queryClient.invalidateQueries({ queryKey: myWorkKeys.tasks() });
   }
 
-  // Filter and group tasks
-  const filteredTasks = useMemo(() => {
-    return filterTasks(tasks ?? [], statusFilter);
-  }, [tasks, statusFilter]);
+  function handleTaskNavigate(task: ProgressTask) {
+    if (!activeProjectId) return;
+    void navigate({
+      to: ROUTE_PATTERNS.PROJECT_TASKS,
+      params: { projectId: activeProjectId },
+      search: { taskSlug: task.slug },
+    });
+  }
+
+  // Filter and sort tasks
+  const processedTasks = useMemo(() => {
+    const statusFiltered = filterByStatus(tasks ?? [], statusFilter);
+    const searchFiltered = filterBySearch(statusFiltered, debouncedSearch);
+    return sortTasks(searchFiltered, sortField);
+  }, [tasks, statusFilter, debouncedSearch, sortField]);
 
   const taskGroups = useMemo(() => {
-    return groupTasksByTeam(filteredTasks);
-  }, [filteredTasks]);
+    return groupTasksByTeam(processedTasks);
+  }, [processedTasks]);
 
-  const totalTasks = filteredTasks.length;
-  const hasFilter = statusFilter !== 'all';
+  const totalTasks = processedTasks.length;
+  const hasFilter = statusFilter !== 'all' || debouncedSearch.trim().length > 0;
 
   return (
     <PageLayout>
@@ -290,8 +514,15 @@ export function MyWorkPage() {
             My Work
           </PageHeader.Title>
           <PageHeader.Actions>
+            <SearchInput
+              className="w-[200px]"
+              placeholder="Search tasks..."
+              value={searchQuery}
+              onChange={(e) => { setSearchQuery(e.target.value); }}
+              onClear={() => { setSearchQuery(''); }}
+            />
             <Filter className="text-muted-foreground h-4 w-4" />
-            <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as StatusFilter)}>
+            <Select value={statusFilter} onValueChange={(v) => { setStatusFilter(v as StatusFilter); }}>
               <SelectTrigger className="w-[140px]">
                 <SelectValue />
               </SelectTrigger>
@@ -303,9 +534,21 @@ export function MyWorkPage() {
                 ))}
               </SelectContent>
             </Select>
-            <span className="text-muted-foreground text-sm">
+            <Select value={sortField} onValueChange={(v) => { setSortField(v as SortField); }}>
+              <SelectTrigger className="w-[130px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SORT_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Text className="text-xs" variant="muted">
               {totalTasks} {getTaskCountLabel(totalTasks)}
-            </span>
+            </Text>
           </PageHeader.Actions>
         </PageHeader.Row>
       </PageHeader>
@@ -315,6 +558,7 @@ export function MyWorkPage() {
           isError={tasksError}
           isLoading={tasksLoading}
           taskGroups={taskGroups}
+          onNavigate={handleTaskNavigate}
           onRetry={handleRetry}
         />
       </PageContent>

--- a/src/renderer/features/personal/alerts/components/AlertsPage.tsx
+++ b/src/renderer/features/personal/alerts/components/AlertsPage.tsx
@@ -9,9 +9,23 @@ import { Bell, Check, Clock, Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
 import type { Alert } from '@shared/types';
 
 import { RelativeTime } from '@renderer/shared/components/RelativeTime';
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
 import { cn } from '@renderer/shared/lib/utils';
 
-import { Badge, Button, EmptyState, PageContent, PageHeader, PageLayout } from '@ui';
+import {
+  Badge,
+  Button,
+  EmptyState,
+  PageContent,
+  PageHeader,
+  PageLayout,
+  SearchInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui';
 
 import { useAlerts, useDeleteAlert, useDismissAlert } from '../api/useAlerts';
 import { useAlertEvents } from '../hooks/useAlertEvents';
@@ -22,6 +36,8 @@ import { CreateAlertModal } from './CreateAlertModal';
 import { RecurringAlerts } from './RecurringAlerts';
 
 type TabId = 'active' | 'dismissed' | 'recurring';
+type SortField = 'triggerAt' | 'createdAt';
+type AlertTypeFilter = 'all' | Alert['type'];
 
 function getAlertIcon(type: Alert['type']) {
   switch (type) {
@@ -56,6 +72,30 @@ function formatTriggerTime(triggerAt: string): string {
   });
 }
 
+function applyFilters(
+  alertList: Alert[],
+  searchQuery: string,
+  typeFilter: AlertTypeFilter,
+  sortField: SortField,
+): Alert[] {
+  let result = alertList;
+
+  if (searchQuery.length > 0) {
+    const lower = searchQuery.toLowerCase();
+    result = result.filter((a) => a.message.toLowerCase().includes(lower));
+  }
+
+  if (typeFilter !== 'all') {
+    result = result.filter((a) => a.type === typeFilter);
+  }
+
+  return [...result].sort((a, b) => {
+    const aVal = new Date(a[sortField]).getTime();
+    const bVal = new Date(b[sortField]).getTime();
+    return aVal - bVal;
+  });
+}
+
 export function AlertsPage() {
   useAlertEvents();
 
@@ -65,9 +105,17 @@ export function AlertsPage() {
   const openCreateModal = useAlertStore((s) => s.openCreateModal);
 
   const [editingAlert, setEditingAlert] = useState<Alert | null>(null);
+  const [searchText, setSearchText] = useState('');
+  const [sortField, setSortField] = useState<SortField>('triggerAt');
+  const [typeFilter, setTypeFilter] = useState<AlertTypeFilter>('all');
+
+  const debouncedSearch = useDebounce(searchText, 250);
 
   const activeAlerts = alerts.filter((a) => !a.dismissed);
   const dismissedAlerts = alerts.filter((a) => a.dismissed);
+
+  const filteredActive = applyFilters(activeAlerts, debouncedSearch, typeFilter, sortField);
+  const filteredDismissed = applyFilters(dismissedAlerts, debouncedSearch, typeFilter, sortField);
 
   const tabs: Array<{ id: TabId; label: string; count: number }> = [
     { id: 'active', label: 'Active', count: activeAlerts.length },
@@ -197,6 +245,48 @@ export function AlertsPage() {
             ))}
           </PageHeader.TabList>
         </PageHeader>
+
+        {/* Filter toolbar */}
+        <div className="border-border flex items-center gap-3 border-b px-4 py-3">
+          <SearchInput
+            aria-label="Search alerts"
+            className="flex-1"
+            placeholder="Search alerts..."
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            onClear={() => setSearchText('')}
+          />
+
+          <Select
+            value={typeFilter}
+            onValueChange={(v) => setTypeFilter(v as AlertTypeFilter)}
+          >
+            <SelectTrigger aria-label="Filter by type" className="w-36">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              <SelectItem value="reminder">Reminder</SelectItem>
+              <SelectItem value="deadline">Deadline</SelectItem>
+              <SelectItem value="notification">Notification</SelectItem>
+              <SelectItem value="recurring">Recurring</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={sortField}
+            onValueChange={(v) => setSortField(v as SortField)}
+          >
+            <SelectTrigger aria-label="Sort by" className="w-40">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="triggerAt">Trigger time</SelectItem>
+              <SelectItem value="createdAt">Created time</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
         <PageContent>
           {isLoading ? (
             <div className="text-muted-foreground flex items-center justify-center py-12 text-sm">
@@ -204,8 +294,8 @@ export function AlertsPage() {
             </div>
           ) : (
             <>
-              <PageHeader.TabContent value="active">{renderAlertList(activeAlerts)}</PageHeader.TabContent>
-              <PageHeader.TabContent value="dismissed">{renderAlertList(dismissedAlerts)}</PageHeader.TabContent>
+              <PageHeader.TabContent value="active">{renderAlertList(filteredActive)}</PageHeader.TabContent>
+              <PageHeader.TabContent value="dismissed">{renderAlertList(filteredDismissed)}</PageHeader.TabContent>
               <PageHeader.TabContent value="recurring">
                 <RecurringAlerts alerts={alerts} />
               </PageHeader.TabContent>

--- a/src/renderer/features/personal/alerts/components/AlertsPage.tsx
+++ b/src/renderer/features/personal/alerts/components/AlertsPage.tsx
@@ -162,7 +162,7 @@ export function AlertsPage() {
               />
 
               <div className="min-w-0 flex-1">
-                <Text size="sm" className="text-foreground font-medium">{alert.message}</Text>
+                <Text className="text-foreground font-medium" size="sm">{alert.message}</Text>
                 <Text
                   className={cn(
                     'text-xs',

--- a/src/renderer/features/personal/alerts/components/AlertsPage.tsx
+++ b/src/renderer/features/personal/alerts/components/AlertsPage.tsx
@@ -25,6 +25,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from '@ui';
 
 import { useAlerts, useDeleteAlert, useDismissAlert } from '../api/useAlerts';
@@ -161,8 +162,8 @@ export function AlertsPage() {
               />
 
               <div className="min-w-0 flex-1">
-                <p className="text-foreground text-sm font-medium">{alert.message}</p>
-                <p
+                <Text size="sm" className="text-foreground font-medium">{alert.message}</Text>
+                <Text
                   className={cn(
                     'text-xs',
                     isOverdue ? 'text-destructive' : 'text-muted-foreground',
@@ -170,7 +171,7 @@ export function AlertsPage() {
                 >
                   {formatTriggerTime(alert.triggerAt)}
                   {alert.recurring === undefined ? '' : ' (recurring)'}
-                </p>
+                </Text>
                 <RelativeTime value={alert.createdAt} />
                 {alert.linkedTo === undefined ? null : (
                   <Badge className="mt-1 text-xs" variant="outline">

--- a/src/renderer/features/personal/fitness/components/BodyComposition.tsx
+++ b/src/renderer/features/personal/fitness/components/BodyComposition.tsx
@@ -40,8 +40,17 @@ export function BodyComposition() {
   const [showForm, setShowForm] = useState(false);
   const [weight, setWeight] = useState('');
   const [bodyFat, setBodyFat] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
 
-  const displayMeasurements = measurements ?? [];
+  const allMeasurements = measurements ?? [];
+
+  const displayMeasurements = allMeasurements.filter((m) => {
+    if (dateFrom && m.date < dateFrom) return false;
+    if (dateTo && m.date > dateTo) return false;
+    return true;
+  });
+
   const latest = displayMeasurements.length > 0 ? displayMeasurements[0] : null;
 
   function handleSubmit() {
@@ -67,8 +76,46 @@ export function BodyComposition() {
     );
   }
 
+  const isFiltered = dateFrom !== '' || dateTo !== '';
+
   return (
     <div className="space-y-4">
+      {/* Date-range filter */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-3">
+        <div className="flex-1">
+          <Label className="mb-1" htmlFor="measure-date-from">
+            From
+          </Label>
+          <Input
+            id="measure-date-from"
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+          />
+        </div>
+        <div className="flex-1">
+          <Label className="mb-1" htmlFor="measure-date-to">
+            To
+          </Label>
+          <Input
+            id="measure-date-to"
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+          />
+        </div>
+        {isFiltered ? (
+          <Button
+            size="sm"
+            type="button"
+            variant="ghost"
+            onClick={() => { setDateFrom(''); setDateTo(''); }}
+          >
+            Clear
+          </Button>
+        ) : null}
+      </div>
+
       {/* Latest measurements */}
       {latest ? (
         <Card>
@@ -123,7 +170,7 @@ export function BodyComposition() {
         </Card>
       ) : (
         <EmptyState
-          description="No measurements recorded yet"
+          description={isFiltered ? 'No measurements in this date range' : 'No measurements recorded yet'}
           icon={Scale}
           size="sm"
           title=""

--- a/src/renderer/features/personal/fitness/components/BodyComposition.tsx
+++ b/src/renderer/features/personal/fitness/components/BodyComposition.tsx
@@ -23,6 +23,7 @@ import {
   Card,
   CardContent,
   EmptyState,
+  Heading,
   Input,
   Label,
   Text,
@@ -120,9 +121,9 @@ export function BodyComposition() {
       {latest ? (
         <Card>
           <CardContent className="p-4">
-            <h4 className="text-muted-foreground mb-3 text-xs font-medium tracking-wider uppercase">
+            <Heading as="h4" className="text-muted-foreground mb-3 text-xs font-medium tracking-wider uppercase">
               Latest Measurements
-            </h4>
+            </Heading>
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
               {latest.weight === undefined ? null : (
                 <div>
@@ -181,7 +182,7 @@ export function BodyComposition() {
       {showForm ? (
         <Card>
           <CardContent className="p-4">
-            <h4 className="text-foreground mb-3 text-sm font-medium">Log Measurement</h4>
+            <Heading as="h4" className="text-foreground mb-3 text-sm font-medium">Log Measurement</Heading>
             <div className="flex gap-3">
               <div className="flex-1">
                 <Label className="mb-1" htmlFor="measure-weight">
@@ -242,9 +243,9 @@ export function BodyComposition() {
       {/* History */}
       {(displayMeasurements.length > 1) ? (
         <Card>
-          <h4 className="text-muted-foreground border-border border-b px-4 py-2 text-xs font-medium tracking-wider uppercase">
+          <Heading as="h4" className="text-muted-foreground border-border border-b px-4 py-2 text-xs font-medium tracking-wider uppercase">
             History
-          </h4>
+          </Heading>
           <div className="divide-border divide-y">
             {displayMeasurements.slice(0, 10).map((m) => (
               <MeasurementHistoryRow key={m.id} measurement={m} />

--- a/src/renderer/features/personal/fitness/components/GoalsPanel.tsx
+++ b/src/renderer/features/personal/fitness/components/GoalsPanel.tsx
@@ -9,6 +9,7 @@ import { Pencil, Plus, Target, Trash2 } from 'lucide-react';
 import type { FitnessGoal, FitnessGoalType } from '@shared/types';
 
 import { RelativeTime } from '@renderer/shared/components/RelativeTime';
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
 
 import {
   AlertDialog,
@@ -26,11 +27,13 @@ import {
   Input,
   Label,
   Progress,
+  SearchInput,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from '@ui';
 
 import { useDeleteGoal, useFitnessGoals, useSetGoal } from '../api/useFitness';
@@ -62,8 +65,14 @@ export function GoalsPanel() {
   const [goalType, setGoalType] = useState<FitnessGoalType>('weight');
   const [target, setTarget] = useState('');
   const [unit, setUnit] = useState('kg');
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedQuery = useDebounce(searchQuery);
 
-  const displayGoals = goals ?? [];
+  const allGoals = goals ?? [];
+
+  const displayGoals = debouncedQuery.trim()
+    ? allGoals.filter((g) => g.type.toLowerCase().includes(debouncedQuery.toLowerCase()))
+    : allGoals;
 
   function handleSubmit() {
     const targetNum = Number(target);
@@ -82,6 +91,16 @@ export function GoalsPanel() {
 
   return (
     <div className="space-y-4">
+      {/* Search */}
+      <SearchInput
+        placeholder="Search goals by type..."
+        showClear={searchQuery.length > 0}
+        size="sm"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        onClear={() => setSearchQuery('')}
+      />
+
       {/* Goals list */}
       {(displayGoals.length > 0) ? (
         <div className="space-y-3">
@@ -91,7 +110,7 @@ export function GoalsPanel() {
         </div>
       ) : (
         <EmptyState
-          description="No goals set yet"
+          description={searchQuery ? 'No goals match your search' : 'No goals set yet'}
           icon={Target}
           size="sm"
           title=""
@@ -211,9 +230,9 @@ function GoalCard({ goal }: GoalCardProps) {
               <span className="text-muted-foreground text-xs font-medium">
                 {GOAL_TYPE_LABELS[goal.type]}
               </span>
-              <p className="text-foreground text-sm font-semibold">
+              <Text className="font-semibold" size="sm">
                 {String(goal.current)} / {String(goal.target)} {goal.unit}
-              </p>
+              </Text>
             </div>
             <div className="flex items-center gap-1">
               <Button
@@ -239,10 +258,10 @@ function GoalCard({ goal }: GoalCardProps) {
             </div>
           </div>
           <Progress className="mt-2" size="sm" value={Math.round(progress)} />
-          <p className="text-muted-foreground mt-1 text-xs">
+          <Text className="mt-1 text-xs" variant="muted">
             {String(Math.round(progress))}% complete
             {goal.deadline ? ` \u00B7 Due ${goal.deadline}` : ''}
-          </p>
+          </Text>
           <div className="mt-1">
             <RelativeTime value={goal.createdAt} />
           </div>

--- a/src/renderer/features/personal/fitness/components/GoalsPanel.tsx
+++ b/src/renderer/features/personal/fitness/components/GoalsPanel.tsx
@@ -24,6 +24,7 @@ import {
   Card,
   CardContent,
   EmptyState,
+  Heading,
   Input,
   Label,
   Progress,
@@ -121,7 +122,7 @@ export function GoalsPanel() {
       {showForm ? (
         <Card>
           <CardContent className="p-4">
-            <h4 className="text-foreground mb-3 text-sm font-medium">Set Goal</h4>
+            <Heading as="h4" className="text-foreground mb-3 text-sm font-medium">Set Goal</Heading>
             <div className="space-y-3">
               <div>
                 <Label className="mb-1" htmlFor="goal-type">

--- a/src/renderer/features/personal/fitness/components/WorkoutLog.tsx
+++ b/src/renderer/features/personal/fitness/components/WorkoutLog.tsx
@@ -9,8 +9,9 @@ import { Pencil, Trash2 } from 'lucide-react';
 import type { Workout } from '@shared/types';
 
 import { RelativeTime } from '@renderer/shared/components/RelativeTime';
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
 
-import { Badge, Button, EmptyState, Text } from '@ui';
+import { Badge, Button, EmptyState, SearchInput, Text } from '@ui';
 
 import { useDeleteWorkout, useWorkouts } from '../api/useFitness';
 
@@ -30,28 +31,45 @@ const TYPE_LABELS: Record<string, string> = {
 export function WorkoutLog() {
   const { data: workouts } = useWorkouts();
   const deleteWorkout = useDeleteWorkout();
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedQuery = useDebounce(searchQuery);
 
-  const displayWorkouts = workouts ?? [];
+  const allWorkouts = workouts ?? [];
 
-  if (displayWorkouts.length === 0) {
-    return (
-      <EmptyState
-        description="No workouts logged yet"
-        size="sm"
-        title=""
-      />
-    );
-  }
+  const displayWorkouts = debouncedQuery.trim()
+    ? allWorkouts.filter((w) => {
+        const q = debouncedQuery.toLowerCase();
+        return w.type.toLowerCase().includes(q) || (w.notes ?? '').toLowerCase().includes(q);
+      })
+    : allWorkouts;
 
   return (
-    <div className="divide-border divide-y">
-      {displayWorkouts.slice(0, 20).map((workout) => (
-        <WorkoutItem
-          key={workout.id}
-          workout={workout}
-          onDelete={() => deleteWorkout.mutate(workout.id)}
+    <div className="flex flex-col gap-3">
+      <SearchInput
+        placeholder="Search workouts by type or notes..."
+        showClear={searchQuery.length > 0}
+        size="sm"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        onClear={() => setSearchQuery('')}
+      />
+      {displayWorkouts.length === 0 ? (
+        <EmptyState
+          description={searchQuery ? 'No workouts match your search' : 'No workouts logged yet'}
+          size="sm"
+          title=""
         />
-      ))}
+      ) : (
+        <div className="divide-border divide-y">
+          {displayWorkouts.slice(0, 20).map((workout) => (
+            <WorkoutItem
+              key={workout.id}
+              workout={workout}
+              onDelete={() => deleteWorkout.mutate(workout.id)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -1,16 +1,19 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { CheckCircle2, Circle, Clock, Map, Pencil, Plus, Sparkles, Square, SquareCheck, Trash2 } from 'lucide-react';
 
 import type { Milestone, MilestoneStatus } from '@shared/types';
 
 import { RelativeTime } from '@renderer/shared/components/RelativeTime';
+import { useDebounce } from '@renderer/shared/hooks/useDebounce';
 import { cn } from '@renderer/shared/lib/utils';
 import { useAssistantWidgetStore, useLayoutStore } from '@renderer/shared/stores';
 
 import {
   Button,
+  EmptyState,
   Input,
+  SearchInput,
   Select,
   SelectContent,
   SelectItem,
@@ -229,6 +232,11 @@ export function RoadmapPage() {
   const [showGenerate, setShowGenerate] = useState(false);
   const [generatePrompt, setGeneratePrompt] = useState(DEFAULT_GENERATE_PROMPT);
   const [editingMilestone, setEditingMilestone] = useState<Milestone | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | MilestoneStatus>('all');
+  const [sortBy, setSortBy] = useState<'targetDate' | 'progress' | 'createdAt'>('targetDate');
+
+  const debouncedSearch = useDebounce(searchInput, 250);
 
   const sendCommand = useSendCommand();
   const openWidget = useAssistantWidgetStore((s) => s.open);
@@ -265,10 +273,73 @@ export function RoadmapPage() {
       ? Math.round(items.reduce((sum, m) => sum + computeProgress(m), 0) / items.length)
       : 0;
 
+  const filteredItems = useMemo(() => {
+    const source = milestones ?? [];
+    const query = debouncedSearch.toLowerCase();
+
+    let result = source.filter((m) => {
+      const matchesSearch =
+        query === '' ||
+        m.title.toLowerCase().includes(query) ||
+        m.description.toLowerCase().includes(query);
+      const matchesStatus = statusFilter === 'all' || m.status === statusFilter;
+      return matchesSearch && matchesStatus;
+    });
+
+    result = [...result].sort((a, b) => {
+      if (sortBy === 'targetDate') {
+        return new Date(a.targetDate).getTime() - new Date(b.targetDate).getTime();
+      }
+      if (sortBy === 'progress') {
+        return computeProgress(b) - computeProgress(a);
+      }
+      // createdAt desc
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+
+    return result;
+  }, [milestones, debouncedSearch, statusFilter, sortBy]);
+
   return (
     <div className="space-y-6 p-6">
       {/* Actions */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
+        <SearchInput
+          className="w-56"
+          placeholder="Search milestones..."
+          size="sm"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onClear={() => setSearchInput('')}
+        />
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as 'all' | MilestoneStatus)}
+        >
+          <SelectTrigger className="h-8 w-[130px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="planned">Planned</SelectItem>
+            <SelectItem value="in-progress">In Progress</SelectItem>
+            <SelectItem value="completed">Completed</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={sortBy}
+          onValueChange={(v) => setSortBy(v as 'targetDate' | 'progress' | 'createdAt')}
+        >
+          <SelectTrigger className="h-8 w-[130px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="targetDate">Target date</SelectItem>
+            <SelectItem value="progress">Progress</SelectItem>
+            <SelectItem value="createdAt">Created at</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="flex-1" />
         <Button
           type="button"
           variant="outline"
@@ -398,13 +469,13 @@ export function RoadmapPage() {
           </div>
         ) : null}
 
-        {!isLoading && items.length > 0 ? (
+        {!isLoading && items.length > 0 && filteredItems.length > 0 ? (
           <section>
             <h2 className="text-muted-foreground mb-4 text-sm font-medium tracking-wider uppercase">
               Timeline
             </h2>
             <div className="space-y-4">
-              {items.map((milestone) => (
+              {filteredItems.map((milestone) => (
                 <MilestoneCard
                   key={milestone.id}
                   milestone={milestone}
@@ -415,6 +486,15 @@ export function RoadmapPage() {
               ))}
             </div>
           </section>
+        ) : null}
+
+        {!isLoading && items.length > 0 && filteredItems.length === 0 ? (
+          <EmptyState
+            description="Try adjusting your search or filters"
+            icon={Map}
+            size="md"
+            title="No milestones match"
+          />
         ) : null}
 
         {!isLoading && items.length === 0 ? (

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -146,7 +146,7 @@ function MilestoneCard({
         </div>
       </div>
 
-      <Text size="sm" className="text-muted-foreground mb-2">{milestone.description}</Text>
+      <Text className="text-muted-foreground mb-2" size="sm">{milestone.description}</Text>
       <Text className="text-muted-foreground mb-3 text-xs">
         Target: {new Date(milestone.targetDate).toLocaleDateString()}
       </Text>
@@ -367,7 +367,7 @@ export function RoadmapPage() {
         {/* Generate with AI Panel */}
         {showGenerate ? (
           <div className="border-border bg-card mb-6 space-y-3 rounded-lg border p-4">
-            <Text size="sm" className="text-muted-foreground">
+            <Text className="text-muted-foreground" size="sm">
               Describe what milestones you want the assistant to generate. It will create them directly on your roadmap.
             </Text>
             <Textarea
@@ -446,13 +446,13 @@ export function RoadmapPage() {
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Total Milestones
             </div>
-            <Text size="lg" className="font-semibold">{items.length}</Text>
+            <Text className="font-semibold" size="lg">{items.length}</Text>
           </div>
           <div className="border-border bg-card rounded-lg border p-4">
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Completed
             </div>
-            <Text size="lg" className="font-semibold">
+            <Text className="font-semibold" size="lg">
               {completedCount} / {items.length}
             </Text>
           </div>
@@ -460,7 +460,7 @@ export function RoadmapPage() {
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Overall Progress
             </div>
-            <Text size="lg" className="font-semibold">{totalProgress}%</Text>
+            <Text className="font-semibold" size="lg">{totalProgress}%</Text>
           </div>
         </div>
 
@@ -502,8 +502,8 @@ export function RoadmapPage() {
         {!isLoading && items.length === 0 ? (
           <div className="border-border rounded-lg border border-dashed p-12 text-center">
             <Map className="text-muted-foreground mx-auto mb-4 h-12 w-12" />
-            <Text size="lg" className="font-medium">No milestones yet</Text>
-            <Text size="sm" className="text-muted-foreground mt-1">
+            <Text className="font-medium" size="lg">No milestones yet</Text>
+            <Text className="text-muted-foreground mt-1" size="sm">
               Create your first milestone to start planning
             </Text>
           </div>

--- a/src/renderer/features/roadmap/components/RoadmapPage.tsx
+++ b/src/renderer/features/roadmap/components/RoadmapPage.tsx
@@ -12,6 +12,7 @@ import { useAssistantWidgetStore, useLayoutStore } from '@renderer/shared/stores
 import {
   Button,
   EmptyState,
+  Heading,
   Input,
   SearchInput,
   Select,
@@ -20,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
   Spinner,
+  Text,
   Textarea,
 } from '@ui';
 
@@ -105,7 +107,7 @@ function MilestoneCard({
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <StatusIcon className={cn('h-5 w-5', config.iconClass)} />
-          <h3 className="font-medium">{milestone.title}</h3>
+          <Heading as="h3" className="font-medium">{milestone.title}</Heading>
         </div>
         <div className="flex items-center gap-2">
           <Select
@@ -144,10 +146,10 @@ function MilestoneCard({
         </div>
       </div>
 
-      <p className="text-muted-foreground mb-2 text-sm">{milestone.description}</p>
-      <p className="text-muted-foreground mb-3 text-xs">
+      <Text size="sm" className="text-muted-foreground mb-2">{milestone.description}</Text>
+      <Text className="text-muted-foreground mb-3 text-xs">
         Target: {new Date(milestone.targetDate).toLocaleDateString()}
-      </p>
+      </Text>
       <div className="mb-3">
         <RelativeTime value={milestone.createdAt} />
       </div>
@@ -365,9 +367,9 @@ export function RoadmapPage() {
         {/* Generate with AI Panel */}
         {showGenerate ? (
           <div className="border-border bg-card mb-6 space-y-3 rounded-lg border p-4">
-            <p className="text-muted-foreground text-sm">
+            <Text size="sm" className="text-muted-foreground">
               Describe what milestones you want the assistant to generate. It will create them directly on your roadmap.
-            </p>
+            </Text>
             <Textarea
               resize="none"
               rows={3}
@@ -444,21 +446,21 @@ export function RoadmapPage() {
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Total Milestones
             </div>
-            <p className="text-lg font-semibold">{items.length}</p>
+            <Text size="lg" className="font-semibold">{items.length}</Text>
           </div>
           <div className="border-border bg-card rounded-lg border p-4">
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Completed
             </div>
-            <p className="text-lg font-semibold">
+            <Text size="lg" className="font-semibold">
               {completedCount} / {items.length}
-            </p>
+            </Text>
           </div>
           <div className="border-border bg-card rounded-lg border p-4">
             <div className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
               Overall Progress
             </div>
-            <p className="text-lg font-semibold">{totalProgress}%</p>
+            <Text size="lg" className="font-semibold">{totalProgress}%</Text>
           </div>
         </div>
 
@@ -471,9 +473,9 @@ export function RoadmapPage() {
 
         {!isLoading && items.length > 0 && filteredItems.length > 0 ? (
           <section>
-            <h2 className="text-muted-foreground mb-4 text-sm font-medium tracking-wider uppercase">
+            <Heading as="h2" className="text-muted-foreground mb-4 text-sm font-medium tracking-wider uppercase">
               Timeline
-            </h2>
+            </Heading>
             <div className="space-y-4">
               {filteredItems.map((milestone) => (
                 <MilestoneCard
@@ -500,10 +502,10 @@ export function RoadmapPage() {
         {!isLoading && items.length === 0 ? (
           <div className="border-border rounded-lg border border-dashed p-12 text-center">
             <Map className="text-muted-foreground mx-auto mb-4 h-12 w-12" />
-            <p className="text-lg font-medium">No milestones yet</p>
-            <p className="text-muted-foreground mt-1 text-sm">
+            <Text size="lg" className="font-medium">No milestones yet</Text>
+            <Text size="sm" className="text-muted-foreground mt-1">
               Create your first milestone to start planning
-            </p>
+            </Text>
           </div>
         ) : null}
 

--- a/src/renderer/features/tasks/components/BulkActionBar.tsx
+++ b/src/renderer/features/tasks/components/BulkActionBar.tsx
@@ -1,0 +1,241 @@
+/**
+ * BulkActionBar — Appears when one or more progress tasks are selected.
+ * Provides Archive, Delete, Change Status, and Change Priority bulk actions.
+ * Destructive actions (Archive, Delete) require AlertDialog confirmation.
+ */
+
+import { useState } from 'react';
+
+import { Trash2, Archive, X } from 'lucide-react';
+
+import type { ProgressPriority, ProgressStatus } from '@shared/types/progress';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Badge,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  Text,
+} from '@ui';
+
+const BULK_STATUSES: ProgressStatus[] = [
+  'backlog',
+  'researching',
+  'research_done',
+  'planning',
+  'plan_ready',
+  'executing',
+  'review',
+  'done',
+];
+
+const STATUS_LABELS: Record<ProgressStatus, string> = {
+  backlog: 'Backlog',
+  researching: 'Researching',
+  research_done: 'Research Done',
+  planning: 'Planning',
+  plan_ready: 'Plan Ready',
+  executing: 'Executing',
+  review: 'Review',
+  done: 'Done',
+  archived: 'Archived',
+  error: 'Error',
+};
+
+const PRIORITY_LABELS: Record<ProgressPriority, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  urgent: 'Urgent',
+};
+
+const ALL_PRIORITIES: ProgressPriority[] = ['low', 'normal', 'high', 'urgent'];
+
+interface BulkActionBarProps {
+  selected: Set<string>;
+  isLoading: boolean;
+  onClear: () => void;
+  onArchive: () => Promise<void>;
+  onDelete: () => Promise<void>;
+  onChangeStatus: (status: ProgressStatus) => Promise<void>;
+  onChangePriority: (priority: ProgressPriority) => Promise<void>;
+}
+
+export function BulkActionBar({
+  selected,
+  isLoading,
+  onClear,
+  onArchive,
+  onDelete,
+  onChangeStatus,
+  onChangePriority,
+}: BulkActionBarProps) {
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const count = selected.size;
+  const hasSelection = count > 0;
+
+  if (!hasSelection) {
+    return null;
+  }
+
+  async function handleArchiveConfirm() {
+    await onArchive();
+    setArchiveOpen(false);
+  }
+
+  async function handleDeleteConfirm() {
+    await onDelete();
+    setDeleteOpen(false);
+  }
+
+  function handleStatusChange(value: string) {
+    void onChangeStatus(value as ProgressStatus);
+  }
+
+  function handlePriorityChange(value: string) {
+    void onChangePriority(value as ProgressPriority);
+  }
+
+  return (
+    <div className="border-border bg-card flex items-center gap-3 border-t px-4 py-2">
+      {/* Selection count */}
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary">
+          {count} selected
+        </Badge>
+        <Button
+          aria-label="Clear selection"
+          size="sm"
+          variant="ghost"
+          onClick={onClear}
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear
+        </Button>
+      </div>
+
+      <div className="bg-border h-5 w-px" />
+
+      {/* Change Status */}
+      <Select onValueChange={handleStatusChange}>
+        <SelectTrigger
+          aria-label="Set status for selected tasks"
+          className="h-8 w-40"
+          disabled={isLoading}
+        >
+          <SelectValue placeholder="Set status…" />
+        </SelectTrigger>
+        <SelectContent>
+          {BULK_STATUSES.map((s) => (
+            <SelectItem key={s} value={s}>
+              {STATUS_LABELS[s]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Change Priority */}
+      <Select onValueChange={handlePriorityChange}>
+        <SelectTrigger
+          aria-label="Set priority for selected tasks"
+          className="h-8 w-36"
+          disabled={isLoading}
+        >
+          <SelectValue placeholder="Set priority…" />
+        </SelectTrigger>
+        <SelectContent>
+          {ALL_PRIORITIES.map((p) => (
+            <SelectItem key={p} value={p}>
+              {PRIORITY_LABELS[p]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="flex-1" />
+
+      {/* Archive */}
+      <AlertDialog open={archiveOpen} onOpenChange={setArchiveOpen}>
+        <AlertDialogTrigger asChild>
+          <Button
+            aria-label={`Archive ${String(count)} selected task${count === 1 ? '' : 's'}`}
+            disabled={isLoading}
+            size="sm"
+            variant="outline"
+          >
+            {isLoading ? <Spinner className="mr-1.5" size="sm" /> : <Archive className="mr-1.5 h-3.5 w-3.5" />}
+            Archive
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive {count} task{count === 1 ? '' : 's'}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <Text className="text-muted-foreground text-sm">
+                This will archive {count === 1 ? 'the selected task' : `all ${String(count)} selected tasks`}. Archived tasks can be restored later.
+              </Text>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => void handleArchiveConfirm()}
+            >
+              Archive
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogTrigger asChild>
+          <Button
+            aria-label={`Delete ${String(count)} selected task${count === 1 ? '' : 's'}`}
+            disabled={isLoading}
+            size="sm"
+            variant="destructive"
+          >
+            {isLoading ? <Spinner className="mr-1.5" size="sm" /> : <Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+            Delete
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {count} task{count === 1 ? '' : 's'}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <Text className="text-muted-foreground text-sm">
+                This will permanently delete {count === 1 ? 'the selected task' : `all ${String(count)} selected tasks`}. This action cannot be undone.
+              </Text>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => void handleDeleteConfirm()}
+            >
+              Delete permanently
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/renderer/features/tasks/components/grid/ProgressTaskGrid.tsx
+++ b/src/renderer/features/tasks/components/grid/ProgressTaskGrid.tsx
@@ -60,8 +60,11 @@ import { useProgressTasks } from '../../api/useProgress';
 import {
   useArchiveProgressTask,
   useCreateProgressTask,
+  useDeleteProgressTask,
   useRunWorkflow,
+  useUpdateProgressTask,
 } from '../../api/useProgressMutations';
+import { BulkActionBar } from '../BulkActionBar';
 import { ProgressTaskDetailRow } from '../detail/ProgressTaskDetailRow';
 import { EditProgressTaskDialog } from '../EditProgressTaskDialog';
 
@@ -660,6 +663,8 @@ export function ProgressTaskGrid() {
   const createTaskMutation = useCreateProgressTask();
   const runWorkflowMutation = useRunWorkflow();
   const archiveTaskMutation = useArchiveProgressTask();
+  const deleteTaskMutation = useDeleteProgressTask();
+  const updateTaskMutation = useUpdateProgressTask();
 
   // Derive active sessions from task status (previously maintained by ProgressContextHydrator)
   const activeSessions = useMemo(() => {
@@ -735,6 +740,53 @@ export function ProgressTaskGrid() {
 
   function handleInlineEdit(task: ProgressTask) {
     setEditTask(task);
+  }
+
+  // Bulk action state
+  const [isBulkLoading, setIsBulkLoading] = useState(false);
+
+  async function handleBulkArchive() {
+    setIsBulkLoading(true);
+    try {
+      await Promise.all([...selectedSlugs].map((slug) => archiveTaskMutation.mutateAsync({ slug })));
+      setSelectedSlugs(new Set());
+    } finally {
+      setIsBulkLoading(false);
+    }
+  }
+
+  async function handleBulkDelete() {
+    setIsBulkLoading(true);
+    try {
+      await Promise.all([...selectedSlugs].map((slug) => deleteTaskMutation.mutateAsync({ slug })));
+      setSelectedSlugs(new Set());
+    } finally {
+      setIsBulkLoading(false);
+    }
+  }
+
+  async function handleBulkChangeStatus(status: ProgressStatus) {
+    setIsBulkLoading(true);
+    try {
+      await Promise.all(
+        [...selectedSlugs].map((slug) => updateTaskMutation.mutateAsync({ slug, updates: { status } })),
+      );
+      setSelectedSlugs(new Set());
+    } finally {
+      setIsBulkLoading(false);
+    }
+  }
+
+  async function handleBulkChangePriority(priority: ProgressPriority) {
+    setIsBulkLoading(true);
+    try {
+      await Promise.all(
+        [...selectedSlugs].map((slug) => updateTaskMutation.mutateAsync({ slug, updates: { priority } })),
+      );
+      setSelectedSlugs(new Set());
+    } finally {
+      setIsBulkLoading(false);
+    }
   }
 
   // Filtered data
@@ -912,6 +964,17 @@ export function ProgressTaskGrid() {
           </Table>
         </div>
       </div>
+
+      {/* Bulk Action Bar */}
+      <BulkActionBar
+        isLoading={isBulkLoading}
+        selected={selectedSlugs}
+        onArchive={handleBulkArchive}
+        onChangePriority={handleBulkChangePriority}
+        onChangeStatus={handleBulkChangeStatus}
+        onClear={() => setSelectedSlugs(new Set())}
+        onDelete={handleBulkDelete}
+      />
 
       {/* New Task Dialog (rendered outside toolbar so it gets proper portal) */}
       <NewTaskDialog

--- a/src/renderer/shared/hooks/index.ts
+++ b/src/renderer/shared/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useAgentHostEvent } from './useAgentHostEvent';
 export type { AgentHostEvent, AgentHostEventType } from './useAgentHostEvent';
 export { useClaudeAuth } from './useClaudeAuth';
+export { useDebounce } from './useDebounce';
 export { useHubEvent } from './useHubEvents';
 export { useIpcEvent } from './useIpcEvent';
 export { useLayoutSync } from './useLayoutSync';

--- a/src/renderer/shared/hooks/useDebounce.ts
+++ b/src/renderer/shared/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delayMs = 250): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary

Sprint 3 from `docs/superpowers/plans/2026-04-11-gap-closure-multi-sprint.md` — makes every major list view searchable/filterable/sortable and adds multi-select bulk operations to progress tasks.

**7 tasks across 3 waves, 2 Guardian rounds.**

## Tasks

- **T1** `useDebounce` shared hook (foundation)
- **T2** Milestones (Roadmap) — search + status filter + sort
- **T3** Alerts — search + type filter + sort
- **T4** Fitness — workout/goal search + measurement date-range filter
- **T5** Agent Dashboard — session-type/status/team/name filters
- **T6** Progress Tasks — bulk archive/delete/status/priority with AlertDialog confirmation
- **T7** My Work — search, priority badges, Jira/PR link badges, sort, row navigation

## Files changed

- `src/renderer/shared/hooks/useDebounce.ts` (new) + barrel export
- `src/renderer/features/tasks/components/BulkActionBar.tsx` (new)
- `RoadmapPage.tsx`, `AlertsPage.tsx`, `WorkoutLog.tsx`, `GoalsPanel.tsx`, `BodyComposition.tsx`, `AgentDashboardPage.tsx`, `ProgressTaskGrid.tsx` (+63 append-only), `MyWorkPage.tsx`

## Agent metrics

12 agents total: 1 hook-engineer (T1), 6 component-engineers (T2-T7), 1 fix agent (Guardian R1), 3 QA reviewers (1 per wave), 2 Guardian rounds. All tasks PASS R1 from QA; Guardian R1 found 16 raw `<p>`/`<h*>` violations, R2 PASS after migration to `<Text>`/`<Heading>` primitives.

## Test plan

- [x] QA passed all 7 tasks on first round
- [x] Codebase Guardian R2 PASS
- [x] `npx tsc --noEmit` clean per task worktree
- [x] `npx eslint <changed-files>` clean per task worktree
- [ ] Manual smoke test of each search/filter/sort surface
- [ ] Manual test of bulk operations (archive/delete confirmation, status/priority change)

## Known notes

- `ProgressTaskGrid.tsx` remains 1000 lines pre-existing; design doc flagged as future refactor — T6 diff is strictly append-only.
- T7 row click uses `activeProjectId` fallback because `ProgressTask` has no `projectId` field — navigation no-ops when no project is active (acceptable design, flagged in QA).
- File size growth on several pages (RoadmapPage 437→519, AlertsPage 224→315, AgentDashboardPage 355→518, MyWorkPage 323→567) — intentional Sprint 3 scope, accepted.

🤖 Sprint 3 executed via /claude-workflow:agent-team