### PR TITLE
fix(release): rebuild better-sqlite3 against Electron ABI (v0.1.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm ci
 
       - name: Rebuild native modules for Electron
-        run: npm rebuild better-sqlite3
+        run: npm run rebuild:sqlite:electron
 
       - name: Typecheck
         run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "ADC — Desktop UI for multi-project management with agent team orchestration, automated QA loops, and agentic local software testing",
   "main": "./out/main/index.cjs",


### PR DESCRIPTION
## Summary
- Installed 0.1.1 crashes on launch: `better-sqlite3` was compiled for Node 22 (ABI 127) instead of Electron 39 (ABI 140).
- Root cause: `.github/workflows/release.yml` ran `npm rebuild better-sqlite3`, which builds against the runner's Node runtime and overwrites the correct `postinstall` output from `electron-rebuild`.
- Switch the workflow to `npm run rebuild:sqlite:electron`, which calls `electron-rebuild` pinned to the installed Electron version.
- Bump version to 0.1.2 so the release job will build and publish a replacement installer.

## Evidence
`%APPDATA%/ADC/logs/main.log` on the user's machine (fresh install of 0.1.1):
```
[Main] Starting ADC on channel=release ...
[Main] Unhandled rejection: The module '...better_sqlite3.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 127. This version of Node.js requires
NODE_MODULE_VERSION 140.
```

## Test plan
- [ ] CI `Release` workflow succeeds for both windows-latest and macos-latest
- [ ] Download the published `ADC-Setup-0.1.2-x64.exe`, install, and confirm the app window opens
- [ ] Confirm main.log no longer shows the NODE_MODULE_VERSION mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)