### PR TITLE
fix(csp): allow user-configured remote hub URLs (v0.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "ADC — Desktop UI for multi-project management with agent team orchestration, automated QA loops, and agentic local software testing",
   "main": "./out/main/index.cjs",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <title>ADC</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:* http://localhost:* https://localhost:*; img-src 'self' data: blob: file: local-file:; font-src 'self'; media-src 'none'; object-src 'none'; frame-src 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https: ws: wss:; img-src 'self' data: blob: file: local-file:; font-src 'self'; media-src 'none'; object-src 'none'; frame-src 'none'"
     />
   </head>
   <body class="bg-background text-foreground antialiased">


### PR DESCRIPTION
## Summary
- Remote Mac client could not call the hub at ``http://192.168.1.134:3200``. All other checks passed (firewall, hub CORS with ``HUB_ALLOWED_ORIGINS=null``, network) but DevTools showed the renderer CSP blocking the fetch before it left the process.
- Root cause: ``src/renderer/index.html`` CSP had ``connect-src 'self' ws://localhost:* http://localhost:* https://localhost:*``. The hub URL is user-configurable (LAN IPs, domains, wss endpoints), so the CSP was strictly narrower than the feature requires.
- Widened ``connect-src`` to ``'self' http: https: ws: wss:``. ``default-src``, ``script-src``, ``frame-src``, etc. remain locked down, so script injection surface is unchanged — only outbound renderer connections are broadened.
- Bumped to 0.1.3 to trigger a release build.

## Console error (before fix)
```
Fetch API cannot load http://192.168.1.134:3200/api/auth/generate-key.
Refused to connect because it violates the document's Content Security Policy.
```

## Test plan
- [ ] CI ``Release`` workflow succeeds for win + mac
- [ ] Install 0.1.3 on a second machine, enter a LAN hub URL (``http://<host-ip>:3200``), click Generate → returns an API key
- [ ] Existing localhost hub flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)