### PR TITLE
fix(0.1.4): CSP unsafe-eval + ad-hoc mac sign + tray icon + shell PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,14 @@ jobs:
       - name: Package and publish (${{ matrix.os }})
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS signing (optional — leave unset to produce an unsigned build)
+          # macOS signing (optional — leave secrets unset to produce an ad-hoc
+          # signed build. mac.identity is "-" in package.json, which satisfies
+          # macOS's arm64 signature requirement and prevents the "damaged" dialog)
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # Disable keychain discovery so the ad-hoc identity in package.json is
+          # always used when no real signing secrets are provided
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/package.json
+++ b/package.json
@@ -179,7 +179,9 @@
       "out/**/*"
     ],
     "extraResources": [
-      "drizzle/**"
+      "drizzle/**",
+      { "from": "resources/icon-16.png", "to": "icon-16.png" },
+      { "from": "resources/icon-32.png", "to": "icon-32.png" }
     ],
     "publish": {
       "provider": "github",
@@ -202,7 +204,7 @@
     "mac": {
       "icon": "resources/icon.icns",
       "category": "public.app-category.developer-tools",
-      "identity": null,
+      "identity": "-",
       "gatekeeperAssess": false,
       "target": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "ADC — Desktop UI for multi-project management with agent team orchestration, automated QA loops, and agentic local software testing",
   "main": "./out/main/index.cjs",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ import {
 } from './bootstrap';
 import { getChannelConfig, resolveChannel } from './lib/channel';
 import { appLogger } from './lib/logger';
+import { inheritShellPath } from './lib/shell-path';
 import { createTrayManager } from './tray/tray-manager';
 
 import type { AgentHostClient } from './agent-host/agent-host-client';
@@ -55,6 +56,11 @@ app.setAppUserModelId(CHANNEL_CFG.aumid);
 process.env.CLAUDE_CONFIG_DIR ??= join(app.getPath('userData'), '.claude');
 
 appLogger.info(`[Main] Starting ADC on channel=${CHANNEL} (name=${CHANNEL_CFG.name}, aumid=${CHANNEL_CFG.aumid})`);
+
+// On macOS/Linux, a packaged .app launched from Finder has a minimal PATH.
+// Pull the user's login-shell PATH + common bin dirs so `which claude` (and
+// any other user-installed CLI we spawn) resolves correctly.
+inheritShellPath();
 
 // Enable remote debugging for DevTools MCP integration
 app.commandLine.appendSwitch('remote-debugging-port', '9222');

--- a/src/main/lib/shell-path.ts
+++ b/src/main/lib/shell-path.ts
@@ -1,0 +1,83 @@
+/**
+ * Inherit the login-shell PATH on macOS/Linux.
+ *
+ * A packaged .app launched from Finder/Launchpad (or via `open`) inherits only
+ * launchd's minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin). That misses Homebrew
+ * (/opt/homebrew/bin, /usr/local/bin), nvm shims, and npm global bins — which
+ * means `which claude` fails and every agent spawn ENOENTs.
+ *
+ * We shell out to the user's login shell once at startup to capture the PATH
+ * the user actually uses in a terminal, and merge it into process.env.PATH.
+ *
+ * Windows inherits PATH from the registry, so this is a no-op there.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { appLogger } from '@main/lib/logger';
+
+/** Location probes added unconditionally — cheap insurance when the shell trick fails. */
+const COMMON_MAC_BIN_DIRS = [
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/opt/local/bin',
+];
+
+const COMMON_HOME_BIN_DIRS = [
+  '.npm-global/bin',
+  '.volta/bin',
+  '.cargo/bin',
+  '.local/bin',
+  'bin',
+];
+
+function readLoginShellPath(shell: string): string | null {
+  try {
+    const out = execFileSync(
+      shell,
+      ['-ilc', 'command printf "%s" "$PATH"'],
+      { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Idempotently merge the user's login-shell PATH and common bin directories
+ * into process.env.PATH. Safe to call multiple times.
+ */
+export function inheritShellPath(): void {
+  if (process.platform === 'win32') return;
+
+  const parts = new Set<string>(
+    (process.env.PATH ?? '').split(':').filter((p) => p.length > 0),
+  );
+
+  const shell = process.env.SHELL && process.env.SHELL.length > 0 ? process.env.SHELL : '/bin/sh';
+  const shellPath = readLoginShellPath(shell);
+  if (shellPath) {
+    for (const dir of shellPath.split(':')) {
+      if (dir.length > 0) parts.add(dir);
+    }
+  }
+
+  if (process.platform === 'darwin') {
+    for (const dir of COMMON_MAC_BIN_DIRS) parts.add(dir);
+  }
+
+  const home = process.env.HOME;
+  if (home && home.length > 0) {
+    for (const suffix of COMMON_HOME_BIN_DIRS) {
+      parts.add(`${home}/${suffix}`);
+    }
+  }
+
+  const merged = [...parts].join(':');
+  if (merged !== process.env.PATH) {
+    process.env.PATH = merged;
+    appLogger.info(`[ShellPath] Inherited PATH (${String(parts.size)} entries) from ${shell}`);
+  }
+}

--- a/src/main/tray/tray-manager.ts
+++ b/src/main/tray/tray-manager.ts
@@ -82,13 +82,26 @@ function createStatusIcon(color: { r: number; g: number; b: number }): NativeIma
   });
 }
 
+function resolveIconPath(): string {
+  // In packaged builds the icons live beside app.asar under resources/ (via
+  // electron-builder extraResources). In dev they live at the repo root.
+  const fileName = 'icon-16.png';
+  return app.isPackaged
+    ? join(process.resourcesPath, fileName)
+    : join(__dirname, '../../resources', fileName);
+}
+
 function loadResourceIcon(): NativeImage {
-  const resourcePath = join(__dirname, '../../resources/icon-16.png');
-  const image = nativeImage.createFromPath(resourcePath);
+  const image = nativeImage.createFromPath(resolveIconPath());
 
   if (image.isEmpty()) {
-    // Fallback: create a default icon programmatically
-    return createStatusIcon({ r: 45, g: 212, b: 191 }); // #2DD4BF — Command teal
+    // Fallback: programmatic circle. Template on darwin so the menu bar
+    // renders it as a monochrome silhouette instead of a raw colored blob.
+    const fallback = createStatusIcon({ r: 45, g: 212, b: 191 }); // #2DD4BF — Command teal
+    if (process.platform === 'darwin') {
+      fallback.setTemplateImage(true);
+    }
+    return fallback;
   }
 
   if (process.platform === 'darwin') {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <title>ADC</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https: ws: wss:; img-src 'self' data: blob: file: local-file:; font-src 'self'; media-src 'none'; object-src 'none'; frame-src 'none'"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https: ws: wss:; img-src 'self' data: blob: file: local-file:; font-src 'self'; media-src 'none'; object-src 'none'; frame-src 'none'"
     />
   </head>
   <body class="bg-background text-foreground antialiased">


### PR DESCRIPTION
Bundled set of fixes so one install covers all the first-launch papercuts.

## Summary

**1. Renderer CSP — allow unsafe-eval + wasm-unsafe-eval**
Zod v4 JIT-compiles schemas with ``new Function()``. Under ``script-src 'self'`` this was blocked, schema validation crashed, and requests went out malformed → hub returned 400 Bad Request. Relaxed ``script-src`` only; all other directives (default-src, connect-src, frame-src, object-src, img-src, font-src) remain strict.

**2. macOS "damaged and can't be opened" → ad-hoc signature**
``mac.identity: null`` → ``mac.identity: "-"`` so electron-builder calls ``codesign --force --sign -``. The ad-hoc signature satisfies arm64's minimum-signature requirement; the normal Gatekeeper right-click → Open flow now works. No Apple Developer account needed. ``CSC_IDENTITY_AUTO_DISCOVERY=false`` in the workflow so the keychain is not probed when real signing secrets are absent.

**3. Tray icon rendering as a solid blob**
``resources/icon-16.png`` was referenced at runtime but never packaged — ``build.files`` is ``["out/**/*"]`` so ``resources/`` was excluded. Added the PNGs to ``extraResources`` and resolved via ``process.resourcesPath`` when ``app.isPackaged``. Also ensured ``setTemplateImage(true)`` on darwin for the programmatic fallback.

**4. Agent spawns ENOENT on packaged macOS**
A ``.app`` launched from Finder inherits only launchd's PATH — no Homebrew, no nvm, no npm global bins. ``which claude`` returned 1 and every agent session silently refused to start. Added ``src/main/lib/shell-path.ts`` which captures the login-shell PATH once at startup and merges in ``/opt/homebrew/bin``, ``/usr/local/bin``, and common home bin dirs. Windows skipped (PATH comes from registry there).

## Test plan
- [ ] CI ``Release`` succeeds for win + mac (both arches)
- [ ] Mac: install ``ADC-0.1.4-*.dmg``, launch from Finder — **no "damaged" dialog**, Gatekeeper shows the standard unidentified-developer warning which right-click → Open bypasses
- [ ] Mac: tray/menu-bar icon shows the ADC logo (template silhouette) instead of a blob
- [ ] Mac: spawn an agent via the app → no ENOENT in ``main.log``
- [ ] Mac: remote hub Generate Key + Connect flow (from 0.1.3 fix) still works — no CSP violation, no 400 Bad Request
- [ ] Windows: tray icon shows the logo at 16×16, install + launch still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)