### PR TITLE
feat(release): mac install script bypasses Gatekeeper quarantine (v0.1.6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts must be LF on all platforms — CRLF breaks bash's shebang
+# parsing on macOS/Linux.
+*.sh text eol=lf
+
+# Same for files run by bash (no extension, shebang-only). If added later,
+# include them by path.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Promote draft release to published
+      - name: Attach macOS install script and promote release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ needs.read-version.outputs.tag }}"
+          # Attach the curl-based macOS installer so users can bypass the
+          # Gatekeeper "damaged" dialog without an Apple Developer subscription.
+          gh release upload "$TAG" scripts/install-mac.sh --clobber
           # electron-builder creates a draft release — publish it now that all platforms succeeded
           if gh release view "$TAG" --json isDraft --jq '.isDraft' | grep -q true; then
             gh release edit "$TAG" --draft=false

--- a/README.md
+++ b/README.md
@@ -172,12 +172,19 @@ ADC is currently distributed unsigned. The first launch shows a security warning
 
 ### macOS
 
-1. Download `ADC-<version>-arm64.dmg` (Apple Silicon) or `ADC-<version>-x64.dmg` (Intel)
-2. Open the DMG and drag **ADC.app** to **Applications**
-3. **Right-click** ADC.app in Applications → **Open** → **Open** in the dialog
-   (Double-clicking the first time will show "ADC can't be opened because Apple cannot check it for malicious software" with no Open button — the right-click bypass is required.)
-4. After the first launch, double-click works normally
-5. Updates are **manual** on macOS — when a new version is available, ADC shows a notification with a Download button that opens the releases page. Drag the new app over the old one to update. Your data persists in `~/Library/Application Support/ADC/`.
+Run this single command in Terminal — it downloads the latest release, installs it to `/Applications`, and strips the Gatekeeper quarantine attribute so macOS doesn't falsely claim the app is "damaged":
+
+```sh
+curl -sSL https://github.com/ParkerM2/Agentic-Desktop-Command/releases/latest/download/install-mac.sh | bash
+```
+
+The script auto-detects arm64 vs x64 and launches ADC when done. After this, double-clicking the app works normally.
+
+> **Why the script?** Browser downloads set `com.apple.quarantine` on the DMG, which on recent macOS (Sonoma 14.5+ / Sequoia) triggers a blanket "damaged" Gatekeeper rejection for any app that isn't Apple-notarized. Notarization requires a paid Apple Developer subscription. Using `curl` bypasses browser quarantine, and the final `xattr -cr` scrubs anything still attached — no paid subscription needed.
+>
+> **Manual install (if you prefer):** Download the DMG from [Releases](https://github.com/ParkerM2/Agentic-Desktop-Command/releases/latest), drag ADC.app to /Applications, then run `xattr -cr /Applications/ADC.app` in Terminal.
+
+Updates are **manual** on macOS — when a new version is available, ADC shows a notification with a Download button that opens the releases page. Run the install script again to update. Your data persists in `~/Library/Application Support/ADC/`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "ADC — Desktop UI for multi-project management with agent team orchestration, automated QA loops, and agentic local software testing",
   "main": "./out/main/index.cjs",

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# ADC macOS installer — downloads the latest release, installs it to
+# /Applications, and strips com.apple.quarantine so Gatekeeper doesn't
+# claim the app is "damaged".
+#
+# Usage:
+#   curl -sSL https://github.com/ParkerM2/Agentic-Desktop-Command/releases/latest/download/install-mac.sh | bash
+#
+# Or download and run locally:
+#   bash install-mac.sh           # latest
+#   bash install-mac.sh 0.1.6     # specific version
+#
+# ADC is distributed unsigned (no Apple Developer subscription). This script
+# is the supported install path — using `curl` to fetch the DMG avoids the
+# browser-applied quarantine attribute that triggers the "damaged" dialog,
+# and the final `xattr -cr` scrubs anything still attached.
+
+set -euo pipefail
+
+REPO="ParkerM2/Agentic-Desktop-Command"
+APP_NAME="ADC"
+VERSION="${1:-latest}"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── Resolve arch ────────────────────────────────────────────────
+arch=$(uname -m)
+case "$arch" in
+  arm64) asset_arch=arm64 ;;
+  x86_64) asset_arch=x64 ;;
+  *) fail "Unsupported architecture: $arch" ;;
+esac
+
+# ── Resolve download URL ────────────────────────────────────────
+if [ "$VERSION" = "latest" ]; then
+  download_base="https://github.com/${REPO}/releases/latest/download"
+else
+  download_base="https://github.com/${REPO}/releases/download/v${VERSION}"
+fi
+
+dmg_name="ADC-${VERSION#v}-${asset_arch}.dmg"
+if [ "$VERSION" = "latest" ]; then
+  # When using /latest/download, filename must match without version prefix:
+  # GitHub serves the latest release asset by exact filename, so we need the
+  # resolved version. Peek at the release JSON.
+  latest_ver=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | awk -F'"' '/"tag_name":/ {print $4; exit}' \
+    | sed 's/^v//')
+  [ -n "$latest_ver" ] || fail "Could not resolve latest version"
+  VERSION="$latest_ver"
+  dmg_name="ADC-${VERSION}-${asset_arch}.dmg"
+  download_base="https://github.com/${REPO}/releases/download/v${VERSION}"
+fi
+
+dmg_url="${download_base}/${dmg_name}"
+tmp_dmg="$(mktemp -t adc-install).dmg"
+trap 'rm -f "$tmp_dmg"' EXIT
+
+log "Downloading ${dmg_name} (${asset_arch})..."
+curl -fLSs -o "$tmp_dmg" "$dmg_url" || fail "Download failed: $dmg_url"
+
+log "Mounting DMG..."
+mount_point=$(hdiutil attach "$tmp_dmg" -nobrowse -noautoopen -quiet \
+  | awk '/Volumes\// { sub(/^[^\/]*/, ""); print; exit }')
+[ -n "$mount_point" ] || fail "Could not determine DMG mount point"
+
+# Ensure we detach on any exit
+cleanup() {
+  rm -f "$tmp_dmg"
+  if [ -n "${mount_point:-}" ] && [ -d "$mount_point" ]; then
+    hdiutil detach "$mount_point" -quiet >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+src_app="${mount_point}/${APP_NAME}.app"
+[ -d "$src_app" ] || fail "Could not find ${APP_NAME}.app in mounted DMG"
+
+dest_app="/Applications/${APP_NAME}.app"
+
+if [ -d "$dest_app" ]; then
+  log "Removing existing installation at ${dest_app}..."
+  rm -rf "$dest_app" || fail "Could not remove existing app (try running with sudo?)"
+fi
+
+log "Copying ${APP_NAME}.app to /Applications..."
+cp -R "$src_app" "$dest_app" || fail "Copy failed — /Applications writable?"
+
+log "Removing quarantine attributes..."
+xattr -cr "$dest_app" || true
+
+log "Installed ${APP_NAME} ${VERSION} (${asset_arch}). Launching..."
+open "$dest_app"


### PR DESCRIPTION
## Summary
Ship ``scripts/install-mac.sh`` as a release asset so Mac users bypass the Gatekeeper "damaged" dialog without an Apple Developer subscription.

## Why
Modern macOS (Sonoma 14.5+ / Sequoia) rejects any quarantined app that is not Apple-notarized with "damaged and can't be opened." Ad-hoc signing (shipped in 0.1.5) satisfies arm64's signature requirement but does not replace notarization. Notarization requires a $99/yr Developer subscription which we are not paying.

The browser applies ``com.apple.quarantine`` when the DMG is downloaded. ``curl`` does not. So: ship an install script users pipe to bash, which fetches the DMG via ``curl``, mounts it, copies ADC.app to /Applications, scrubs xattrs defensively, and launches the app.

## Changes
- ``scripts/install-mac.sh`` — self-contained installer, auto-detects arm64 vs x64, supports pinned or ``latest``
- ``.github/workflows/release.yml`` — ``finalize-release`` now uploads the script as a release asset before promoting the draft
- ``README.md`` — replace the stale right-click → Open instructions (which don't work on recent macOS) with the one-liner
- ``.gitattributes`` — force LF on ``*.sh`` so Windows autocrlf doesn't corrupt the shebang

## One-liner for users
```sh
curl -sSL https://github.com/ParkerM2/Agentic-Desktop-Command/releases/latest/download/install-mac.sh | bash
```

## Test plan
- [ ] CI succeeds, release 0.1.6 published with ``install-mac.sh`` in assets
- [ ] On a clean Mac, run the one-liner — downloads, installs, launches ADC with **no "damaged" dialog**
- [ ] ``ls -la@ /Applications/ADC.app`` shows no ``com.apple.quarantine`` attribute
- [ ] Existing manual-DMG path still works (with ``xattr -cr`` follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)