### PR TITLE
feat(peers): P2P sync phase 1 — SQLite op-log + HLC + column-LWW on progress_tasks

### DIFF
--- a/docs/peers/phase1-dev-harness.md
+++ b/docs/peers/phase1-dev-harness.md
@@ -1,0 +1,61 @@
+# Phase 1 Dev Harness — Two-Instance Peer Sync
+
+Two ADC instances on one machine, each with a hardcoded peer address pointing at the other. Writes to `progress_tasks` on one instance appear on the other within ~1 second over WebSocket.
+
+The `ADC-Dev` and `ADC-Local` channels have isolated `userData` directories, so they don't collide on a single machine.
+
+## Terminal 1 — ADC-Dev (peer A)
+
+```bash
+ADC_PEER_PORT=7701 \
+ADC_PEER_REMOTE=ws://127.0.0.1:7702 \
+ADC_PEER_ID_SHORT=aaaaaaaa \
+ADC_PEER_ID_FULL=peer-a \
+npm run dev
+```
+
+## Terminal 2 — ADC-Local (peer B)
+
+Build once:
+
+```bash
+npm run build:local
+```
+
+`npm run build:local` invokes `electron-vite build` with `ADC_CHANNEL=local`, then runs `electron-builder --win --dir` with `productName=ADC-Local`. The unpacked binary lands in `release/win-unpacked/ADC-Local.exe` (electron-builder `output: release` from `package.json`).
+
+There is no `start:local` / `preview:local` script. Launch the binary directly with env vars:
+
+```bash
+ADC_PEER_PORT=7702 \
+ADC_PEER_REMOTE=ws://127.0.0.1:7701 \
+ADC_PEER_ID_SHORT=bbbbbbbb \
+ADC_PEER_ID_FULL=peer-b \
+./release/win-unpacked/ADC-Local.exe
+```
+
+(macOS/Linux builds will have a different path — `release/mac/ADC-Local.app/Contents/MacOS/ADC-Local` or `release/linux-unpacked/adc-local`. Phase 1 harness was validated on Windows only.)
+
+## What to verify
+
+1. Both windows open. Main-process logs should show `WsTransport listening on 770X` on both sides and a successful outbound connect on both sides.
+2. In peer A's UI, create a new progress task with slug `sync-test-1` and title "Created on A".
+3. Within ~1 second, peer B's progress view should show `sync-test-1`. (You may need to refresh if the renderer doesn't live-subscribe yet — Phase 1 does not wire renderer events, so expect a stale cache until the next service read.)
+4. On peer B, update the task title to "Edited on B". Peer A should update within ~1 second.
+5. On peer A, change the status to `executing`. On peer B, edit the title to "Title from B".
+6. Both peers should converge to `status=executing` AND the latest title. Column-level LWW means neither edit clobbers the other.
+7. On peer A, archive the task. On peer B, confirm the archive applied.
+8. On peer A, delete the task. On peer B, confirm the row disappears.
+
+## Troubleshooting
+
+- **"address already in use"** — another instance bound the port. Kill: `taskkill //F //IM electron.exe` (Windows) or `pkill -f electron` (macOS/Linux). Per the project's "always kill before start" convention.
+- **Peer does not connect** — verify both env vars are exported in the shell that ran the launch. Env vars set after launch don't take effect.
+- **Write on peer A never reaches peer B** — check peer A's main-process logs for `broadcastOp` (if logged at debug level) or any `applyRemoteOp threw` messages. If absent, the service might not be calling `recordLocalWrite`. Grep `progress-service.ts` for `recordLocalWrite` — there should be 4 call sites.
+- **Schema mismatch** — Phase 1 does not validate schema hash (Phase 2). Both instances must be on the same `drizzle/` migration set. If you switch branches, re-build and re-launch both.
+
+## Scope reminders
+
+- Phase 1 replicates ONLY `progress_tasks` (see `src/shared/replication/sync-tables.ts`).
+- No mDNS discovery, no PIN pairing, no TLS. Hardcoded peer addresses only.
+- The renderer does not auto-refresh on incoming sync events — Phase 4 work. Triggering a re-fetch (navigating away and back) shows the updated state.

--- a/drizzle/0026_op_log_and_row_meta.sql
+++ b/drizzle/0026_op_log_and_row_meta.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS op_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  hlc TEXT NOT NULL,
+  origin_peer_id TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  pk TEXT NOT NULL,
+  op_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  applied_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS op_log_peer_hlc ON op_log(origin_peer_id, hlc);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS op_log_dedup ON op_log(origin_peer_id, hlc);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS row_meta (
+  table_name TEXT NOT NULL,
+  pk TEXT NOT NULL,
+  column_name TEXT NOT NULL,
+  hlc TEXT NOT NULL,
+  origin_peer_id TEXT NOT NULL,
+  PRIMARY KEY (table_name, pk, column_name)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS row_meta_by_row ON row_meta(table_name, pk);

--- a/drizzle/0026_op_log_and_row_meta.sql
+++ b/drizzle/0026_op_log_and_row_meta.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS op_log (
+CREATE TABLE op_log (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   hlc TEXT NOT NULL,
   origin_peer_id TEXT NOT NULL,
@@ -9,11 +9,9 @@ CREATE TABLE IF NOT EXISTS op_log (
   applied_at INTEGER NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS op_log_peer_hlc ON op_log(origin_peer_id, hlc);
+CREATE UNIQUE INDEX op_log_dedup ON op_log(origin_peer_id, hlc);
 --> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS op_log_dedup ON op_log(origin_peer_id, hlc);
---> statement-breakpoint
-CREATE TABLE IF NOT EXISTS row_meta (
+CREATE TABLE row_meta (
   table_name TEXT NOT NULL,
   pk TEXT NOT NULL,
   column_name TEXT NOT NULL,
@@ -22,4 +20,4 @@ CREATE TABLE IF NOT EXISTS row_meta (
   PRIMARY KEY (table_name, pk, column_name)
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS row_meta_by_row ON row_meta(table_name, pk);
+CREATE INDEX row_meta_by_row ON row_meta(table_name, pk);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1776500000000,
       "tag": "0025_test_suite_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1776600000000,
+      "tag": "0026_op_log_and_row_meta",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -112,6 +112,7 @@
         "eslint-plugin-react-refresh": "^0.4.26",
         "eslint-plugin-sonarjs": "^3.0.7",
         "eslint-plugin-unicorn": "^58.0.0",
+        "fast-check": "^4.7.0",
         "gif-encoder-2": "^1.0.5",
         "globals": "^16.5.0",
         "icon-gen": "^5.0.0",
@@ -10920,6 +10921,29 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -15768,6 +15792,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "eslint-plugin-react-refresh": "^0.4.26",
     "eslint-plugin-sonarjs": "^3.0.7",
     "eslint-plugin-unicorn": "^58.0.0",
+    "fast-check": "^4.7.0",
     "gif-encoder-2": "^1.0.5",
     "globals": "^16.5.0",
     "icon-gen": "^5.0.0",

--- a/src/main/bootstrap/service-registry.ts
+++ b/src/main/bootstrap/service-registry.ts
@@ -70,6 +70,9 @@ import { createInsightsService } from '../features/insights/insights-service';
 import { createIntegrationsService } from '../features/integrations/integrations-service';
 import { createMergeService } from '../features/merge/merge-service';
 import { createNotesService } from '../features/notes/notes-service';
+import { loadPhase1PeerConfig } from '../features/peers/peer-config';
+import { createReplicationEngine } from '../features/peers/replication-engine';
+import { createWsTransport } from '../features/peers/ws-transport';
 import { createPlannerService } from '../features/planner/planner-service';
 import { createProgressService } from '../features/progress';
 import { createClaudeMdGenerator } from '../features/projects/claudemd-generator';
@@ -519,7 +522,29 @@ export function createServiceRegistry(
   const sessionJsonlReaderService = lazyService(() => createSessionJSONLReaderService());
   const fileTreeService = lazyService(() => createFileTreeService());
   const visualizationService = lazyService(() => createVisualizationService(agentHostClient));
-  const progressService = lazyService(() => createProgressService(process.cwd(), agentHostClient, db));
+  // ─── Peer replication (Phase 1) ──────────────────────────────
+  const peerConfig = loadPhase1PeerConfig();
+  const replicationEngine = createReplicationEngine({
+    db,
+    peerIdShort: peerConfig.peerIdShort,
+    peerIdFull: peerConfig.peerIdFull,
+  });
+
+  if (peerConfig.listenPort > 0) {
+    // Fire-and-forget: WS transport is optional and starts asynchronously.
+    // Errors are logged; replication-engine remains functional without it.
+    createWsTransport({
+      engine: replicationEngine,
+      listenPort: peerConfig.listenPort,
+      remoteUrl: peerConfig.remoteUrl,
+    }).catch((err: unknown) => {
+      appLogger.error(`[Bootstrap] WS transport failed to start: ${String(err)}`);
+    });
+  }
+
+  const progressService = lazyService(() =>
+    createProgressService(process.cwd(), agentHostClient, db, replicationEngine),
+  );
 
   // ─── User session change handling ────────────────────────────
 

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -23,3 +23,4 @@ export * from '../features/assistant/schema';
 export * from '../features/test-suite/schema';
 export * from '../features/workspace/workspaces-schema';
 export * from '../features/runners/schema';
+export * from '../features/peers/schema';

--- a/src/main/features/peers/lww-merge.ts
+++ b/src/main/features/peers/lww-merge.ts
@@ -1,0 +1,73 @@
+import { compareHlc } from '@shared/replication/hlc';
+import { TOMBSTONE_COLUMN, type Op } from '@shared/replication/op-types';
+
+export type RowMetaState = Record<string, { hlc: string; originPeerId: string } | undefined>;
+
+export interface RowMetaUpdate {
+  columnName: string;
+  hlc: string;
+  originPeerId: string;
+}
+
+export interface MergeResult {
+  /** Column → new value. Apply these as a SQL UPDATE (or INSERT for op_type=insert). */
+  columnsToApply: Record<string, unknown>;
+  /** Rows to upsert into `row_meta`. */
+  rowMetaUpdates: RowMetaUpdate[];
+  /** True if the op is a delete that wins over current state. Caller should physically delete the row. */
+  tombstone: boolean;
+  /** True if update wins over an existing tombstone — caller must clear the tombstone row_meta. */
+  resurrectTombstone: boolean;
+}
+
+function incomingWins(meta: RowMetaState, column: string, incomingHlc: string): boolean {
+  const local = meta[column];
+  if (!local) return true;
+  return compareHlc(incomingHlc, local.hlc) > 0;
+}
+
+export function mergeOp(meta: RowMetaState, op: Op): MergeResult {
+  const result: MergeResult = {
+    columnsToApply: {},
+    rowMetaUpdates: [],
+    tombstone: false,
+    resurrectTombstone: false,
+  };
+
+  const tombstoneMeta = meta[TOMBSTONE_COLUMN];
+
+  if (op.opType === 'delete') {
+    if (incomingWins(meta, TOMBSTONE_COLUMN, op.hlc)) {
+      result.tombstone = true;
+      result.rowMetaUpdates.push({
+        columnName: TOMBSTONE_COLUMN,
+        hlc: op.hlc,
+        originPeerId: op.originPeerId,
+      });
+    }
+    return result;
+  }
+
+  // insert or update: check tombstone first
+  if (tombstoneMeta) {
+    if (compareHlc(op.hlc, tombstoneMeta.hlc) <= 0) {
+      // Tombstone still wins — discard this op entirely.
+      return result;
+    }
+    // Resurrection: op hlc beats tombstone hlc.
+    result.resurrectTombstone = true;
+  }
+
+  for (const [column, cv] of Object.entries(op.payload)) {
+    if (incomingWins(meta, column, cv.hlc)) {
+      result.columnsToApply[column] = cv.value;
+      result.rowMetaUpdates.push({
+        columnName: column,
+        hlc: cv.hlc,
+        originPeerId: op.originPeerId,
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/main/features/peers/op-log.ts
+++ b/src/main/features/peers/op-log.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, gt } from 'drizzle-orm';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
+import type { AdcDatabase } from '@main/db';
 import { opLog as opLogTable } from '@main/features/peers/schema';
 
 import type { Op } from '@shared/replication/op-types';
@@ -10,9 +10,7 @@ export interface OpLogService {
   readSince: (originPeerId: string, sinceHlc: string | null) => Op[];
 }
 
-export function createOpLogService(
-  db: BetterSQLite3Database<Record<string, unknown>>,
-): OpLogService {
+export function createOpLogService(db: AdcDatabase): OpLogService {
   return {
     append(op) {
       db.insert(opLogTable)

--- a/src/main/features/peers/op-log.ts
+++ b/src/main/features/peers/op-log.ts
@@ -1,9 +1,10 @@
 import { and, asc, eq, gt } from 'drizzle-orm';
 
+import type { Op } from '@shared/replication/op-types';
+
 import type { AdcDatabase } from '@main/db';
 import { opLog as opLogTable } from '@main/features/peers/schema';
 
-import type { Op } from '@shared/replication/op-types';
 
 export interface OpLogService {
   append: (op: Op) => void;
@@ -46,7 +47,7 @@ export function createOpLogService(db: AdcDatabase): OpLogService {
         tableName: r.tableName as Op['tableName'],
         pk: r.pk,
         opType: r.opType,
-        payload: JSON.parse(r.payload),
+        payload: JSON.parse(r.payload) as Op['payload'],
       }));
     },
   };

--- a/src/main/features/peers/op-log.ts
+++ b/src/main/features/peers/op-log.ts
@@ -1,0 +1,55 @@
+import { and, asc, eq, gt } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import { opLog as opLogTable } from '@main/features/peers/schema';
+
+import type { Op } from '@shared/replication/op-types';
+
+export interface OpLogService {
+  append: (op: Op) => void;
+  readSince: (originPeerId: string, sinceHlc: string | null) => Op[];
+}
+
+export function createOpLogService(
+  db: BetterSQLite3Database<Record<string, unknown>>,
+): OpLogService {
+  return {
+    append(op) {
+      db.insert(opLogTable)
+        .values({
+          hlc: op.hlc,
+          originPeerId: op.originPeerId,
+          tableName: op.tableName,
+          pk: op.pk,
+          opType: op.opType,
+          payload: JSON.stringify(op.payload),
+          appliedAt: Date.now(),
+        })
+        .onConflictDoNothing()
+        .run();
+    },
+
+    readSince(originPeerId, sinceHlc) {
+      const whereClause =
+        sinceHlc === null
+          ? eq(opLogTable.originPeerId, originPeerId)
+          : and(eq(opLogTable.originPeerId, originPeerId), gt(opLogTable.hlc, sinceHlc));
+
+      const rows = db
+        .select()
+        .from(opLogTable)
+        .where(whereClause)
+        .orderBy(asc(opLogTable.hlc))
+        .all();
+
+      return rows.map((r) => ({
+        hlc: r.hlc,
+        originPeerId: r.originPeerId,
+        tableName: r.tableName as Op['tableName'],
+        pk: r.pk,
+        opType: r.opType,
+        payload: JSON.parse(r.payload),
+      }));
+    },
+  };
+}

--- a/src/main/features/peers/peer-config.ts
+++ b/src/main/features/peers/peer-config.ts
@@ -1,0 +1,20 @@
+export interface Phase1PeerConfig {
+  /** This peer's listen port. */
+  listenPort: number;
+  /** Remote peer address to connect to (ws://host:port). Empty string = do not connect. */
+  remoteUrl: string;
+  /** This peer's short id (8 hex chars). */
+  peerIdShort: string;
+  /** This peer's full id (64 hex chars). */
+  peerIdFull: string;
+}
+
+export function loadPhase1PeerConfig(): Phase1PeerConfig {
+  const parsedPort = Number(process.env.ADC_PEER_PORT ?? '0');
+  return {
+    listenPort: Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : 0,
+    remoteUrl: process.env.ADC_PEER_REMOTE ?? '',
+    peerIdShort: process.env.ADC_PEER_ID_SHORT ?? 'aaaaaaaa',
+    peerIdFull: process.env.ADC_PEER_ID_FULL ?? 'peer-a',
+  };
+}

--- a/src/main/features/peers/replication-engine.ts
+++ b/src/main/features/peers/replication-engine.ts
@@ -1,0 +1,222 @@
+import { and, eq, sql } from 'drizzle-orm';
+
+import type { AdcDatabase } from '@main/db';
+import { createOpLogService, type OpLogService } from '@main/features/peers/op-log';
+import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
+import { rowMeta as rowMetaTable } from '@main/features/peers/schema';
+
+import { nextHlc, receiveHlc } from '@shared/replication/hlc';
+import { isSyncTable, type SyncTable } from '@shared/replication/sync-tables';
+import { TOMBSTONE_COLUMN, type Op } from '@shared/replication/op-types';
+
+export interface ReplicationEngineDeps {
+  db: AdcDatabase;
+  peerIdShort: string;
+  peerIdFull: string;
+  clock?: () => number;
+}
+
+export interface RecordLocalWriteArgs {
+  tableName: SyncTable;
+  pk: string;
+  opType: 'insert' | 'update' | 'delete';
+  columns: Record<string, unknown>;
+}
+
+export interface ReplicationEngine {
+  recordLocalWrite: (args: RecordLocalWriteArgs) => Op;
+  applyRemoteOp: (op: Op) => void;
+  getLastHlc: () => string | null;
+  onLocalOp: (listener: (op: Op) => void) => () => void;
+}
+
+type SqliteClient = { prepare: (q: string) => { run: (...a: unknown[]) => void } };
+
+function $client(db: AdcDatabase): SqliteClient {
+  return (db as unknown as { $client: SqliteClient }).$client;
+}
+
+export function createReplicationEngine(deps: ReplicationEngineDeps): ReplicationEngine {
+  const { db, peerIdShort, peerIdFull } = deps;
+  const clock = deps.clock ?? (() => Date.now());
+  const opLog: OpLogService = createOpLogService(db);
+
+  let lastHlc: string | null = null;
+  const localOpListeners = new Set<(op: Op) => void>();
+
+  function loadRowMeta(tableName: string, pk: string): RowMetaState {
+    const rows = db
+      .select()
+      .from(rowMetaTable)
+      .where(and(eq(rowMetaTable.tableName, tableName), eq(rowMetaTable.pk, pk)))
+      .all();
+    const state: RowMetaState = {};
+    for (const r of rows) {
+      state[r.columnName] = { hlc: r.hlc, originPeerId: r.originPeerId };
+    }
+    return state;
+  }
+
+  function upsertRowMeta(
+    tableName: string,
+    pk: string,
+    updates: Array<{ columnName: string; hlc: string; originPeerId: string }>,
+  ): void {
+    for (const u of updates) {
+      db.insert(rowMetaTable)
+        .values({
+          tableName,
+          pk,
+          columnName: u.columnName,
+          hlc: u.hlc,
+          originPeerId: u.originPeerId,
+        })
+        .onConflictDoUpdate({
+          target: [rowMetaTable.tableName, rowMetaTable.pk, rowMetaTable.columnName],
+          set: { hlc: u.hlc, originPeerId: u.originPeerId },
+          where: sql`${rowMetaTable.hlc} < ${u.hlc}`,
+        })
+        .run();
+    }
+  }
+
+  function applyColumnsToUserTable(
+    tableName: SyncTable,
+    pk: string,
+    columns: Record<string, unknown>,
+    opType: 'insert' | 'update',
+  ): void {
+    if (Object.keys(columns).length === 0) return;
+    const session = $client(db);
+    const cols = Object.keys(columns);
+    const placeholders = cols.map(() => '?').join(', ');
+    const values = cols.map((c) => columns[c]);
+
+    if (opType === 'insert') {
+      session
+        .prepare(
+          `INSERT INTO ${tableName} (${cols.map((c) => `"${c}"`).join(', ')}) VALUES (${placeholders})
+           ON CONFLICT(slug) DO UPDATE SET ${cols.map((c) => `"${c}"=excluded."${c}"`).join(', ')}`,
+        )
+        .run(...values);
+    } else {
+      session
+        .prepare(`UPDATE ${tableName} SET ${cols.map((c) => `"${c}"=?`).join(', ')} WHERE slug=?`)
+        .run(...values, pk);
+    }
+  }
+
+  function deleteFromUserTable(tableName: SyncTable, pk: string): void {
+    $client(db).prepare(`DELETE FROM ${tableName} WHERE slug=?`).run(pk);
+  }
+
+  return {
+    recordLocalWrite(args) {
+      if (!isSyncTable(args.tableName)) {
+        throw new Error(`recordLocalWrite called on non-sync table: ${args.tableName}`);
+      }
+
+      const hlc = nextHlc({ lastHlc, wallClockMs: clock(), peerIdShort });
+      lastHlc = hlc;
+
+      const payload: Op['payload'] = {};
+      if (args.opType !== 'delete') {
+        for (const [col, value] of Object.entries(args.columns)) {
+          payload[col] = { value, hlc };
+        }
+      }
+
+      const op: Op = {
+        hlc,
+        originPeerId: peerIdFull,
+        tableName: args.tableName,
+        pk: args.pk,
+        opType: args.opType,
+        payload,
+      };
+
+      db.transaction(() => {
+        opLog.append(op);
+        if (args.opType === 'delete') {
+          db.delete(rowMetaTable)
+            .where(and(eq(rowMetaTable.tableName, args.tableName), eq(rowMetaTable.pk, args.pk)))
+            .run();
+          upsertRowMeta(args.tableName, args.pk, [
+            { columnName: TOMBSTONE_COLUMN, hlc, originPeerId: peerIdFull },
+          ]);
+        } else {
+          upsertRowMeta(
+            args.tableName,
+            args.pk,
+            Object.keys(args.columns).map((columnName) => ({
+              columnName,
+              hlc,
+              originPeerId: peerIdFull,
+            })),
+          );
+        }
+      });
+
+      for (const l of localOpListeners) {
+        try {
+          l(op);
+        } catch (err) {
+          console.error('localOpListener threw', err);
+        }
+      }
+
+      return op;
+    },
+
+    applyRemoteOp(op) {
+      if (!isSyncTable(op.tableName)) return;
+
+      lastHlc = receiveHlc(lastHlc, op.hlc);
+
+      db.transaction(() => {
+        const meta = loadRowMeta(op.tableName, op.pk);
+        const result = mergeOp(meta, op);
+
+        if (result.tombstone) {
+          deleteFromUserTable(op.tableName, op.pk);
+          db.delete(rowMetaTable)
+            .where(and(eq(rowMetaTable.tableName, op.tableName), eq(rowMetaTable.pk, op.pk)))
+            .run();
+        }
+
+        if (result.resurrectTombstone) {
+          db.delete(rowMetaTable)
+            .where(
+              and(
+                eq(rowMetaTable.tableName, op.tableName),
+                eq(rowMetaTable.pk, op.pk),
+                eq(rowMetaTable.columnName, TOMBSTONE_COLUMN),
+              ),
+            )
+            .run();
+        }
+
+        if (Object.keys(result.columnsToApply).length > 0) {
+          applyColumnsToUserTable(
+            op.tableName,
+            op.pk,
+            result.columnsToApply,
+            op.opType === 'insert' ? 'insert' : 'update',
+          );
+        }
+
+        upsertRowMeta(op.tableName, op.pk, result.rowMetaUpdates);
+        opLog.append(op);
+      });
+    },
+
+    getLastHlc() {
+      return lastHlc;
+    },
+
+    onLocalOp(listener) {
+      localOpListeners.add(listener);
+      return () => localOpListeners.delete(listener);
+    },
+  };
+}

--- a/src/main/features/peers/replication-engine.ts
+++ b/src/main/features/peers/replication-engine.ts
@@ -1,14 +1,15 @@
 import { and, eq, sql } from 'drizzle-orm';
 
+import { nextHlc, receiveHlc } from '@shared/replication/hlc';
+import { TOMBSTONE_COLUMN, type Op } from '@shared/replication/op-types';
+import { isSyncTable, SYNC_TABLE_PK, type SyncTable } from '@shared/replication/sync-tables';
+
 import type { AdcDatabase } from '@main/db';
-import { createOpLogService, type OpLogService } from '@main/features/peers/op-log';
 import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
+import { createOpLogService, type OpLogService } from '@main/features/peers/op-log';
 import { rowMeta as rowMetaTable } from '@main/features/peers/schema';
 import { serviceLogger } from '@main/lib/logger';
 
-import { nextHlc, receiveHlc } from '@shared/replication/hlc';
-import { isSyncTable, SYNC_TABLE_PK, type SyncTable } from '@shared/replication/sync-tables';
-import { TOMBSTONE_COLUMN, type Op } from '@shared/replication/op-types';
 
 const COLUMN_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -33,7 +34,7 @@ export interface ReplicationEngine {
   onLocalOp: (listener: (op: Op) => void) => () => void;
 }
 
-type SqliteClient = { prepare: (q: string) => { run: (...a: unknown[]) => void } };
+interface SqliteClient { prepare: (q: string) => { run: (...a: unknown[]) => void } }
 
 function $client(db: AdcDatabase): SqliteClient {
   return (db as unknown as { $client: SqliteClient }).$client;
@@ -125,7 +126,7 @@ export function createReplicationEngine(deps: ReplicationEngineDeps): Replicatio
   return {
     recordLocalWrite(args) {
       if (!isSyncTable(args.tableName)) {
-        throw new Error(`recordLocalWrite called on non-sync table: ${args.tableName}`);
+        throw new Error(`recordLocalWrite called on non-sync table: ${String(args.tableName)}`);
       }
 
       const hlc = nextHlc({ lastHlc, wallClockMs: clock(), peerIdShort });

--- a/src/main/features/peers/replication-engine.ts
+++ b/src/main/features/peers/replication-engine.ts
@@ -4,10 +4,13 @@ import type { AdcDatabase } from '@main/db';
 import { createOpLogService, type OpLogService } from '@main/features/peers/op-log';
 import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
 import { rowMeta as rowMetaTable } from '@main/features/peers/schema';
+import { serviceLogger } from '@main/lib/logger';
 
 import { nextHlc, receiveHlc } from '@shared/replication/hlc';
-import { isSyncTable, type SyncTable } from '@shared/replication/sync-tables';
+import { isSyncTable, SYNC_TABLE_PK, type SyncTable } from '@shared/replication/sync-tables';
 import { TOMBSTONE_COLUMN, type Op } from '@shared/replication/op-types';
+
+const COLUMN_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface ReplicationEngineDeps {
   db: AdcDatabase;
@@ -87,27 +90,36 @@ export function createReplicationEngine(deps: ReplicationEngineDeps): Replicatio
     opType: 'insert' | 'update',
   ): void {
     if (Object.keys(columns).length === 0) return;
+    for (const col of Object.keys(columns)) {
+      if (!COLUMN_NAME_RE.test(col)) {
+        throw new Error(`invalid column name in remote op: ${col}`);
+      }
+    }
     const session = $client(db);
     const cols = Object.keys(columns);
     const placeholders = cols.map(() => '?').join(', ');
     const values = cols.map((c) => columns[c]);
+    const pkCol = SYNC_TABLE_PK[tableName];
 
     if (opType === 'insert') {
       session
         .prepare(
           `INSERT INTO ${tableName} (${cols.map((c) => `"${c}"`).join(', ')}) VALUES (${placeholders})
-           ON CONFLICT(slug) DO UPDATE SET ${cols.map((c) => `"${c}"=excluded."${c}"`).join(', ')}`,
+           ON CONFLICT("${pkCol}") DO UPDATE SET ${cols.map((c) => `"${c}"=excluded."${c}"`).join(', ')}`,
         )
         .run(...values);
     } else {
       session
-        .prepare(`UPDATE ${tableName} SET ${cols.map((c) => `"${c}"=?`).join(', ')} WHERE slug=?`)
+        .prepare(`UPDATE ${tableName} SET ${cols.map((c) => `"${c}"=?`).join(', ')} WHERE "${pkCol}"=?`)
         .run(...values, pk);
     }
   }
 
+  // tableName is a branded SyncTable (guarded by isSyncTable), so interpolating it
+  // and the PK column from SYNC_TABLE_PK is safe — both come from a closed allowlist.
   function deleteFromUserTable(tableName: SyncTable, pk: string): void {
-    $client(db).prepare(`DELETE FROM ${tableName} WHERE slug=?`).run(pk);
+    const pkCol = SYNC_TABLE_PK[tableName];
+    $client(db).prepare(`DELETE FROM ${tableName} WHERE "${pkCol}"=?`).run(pk);
   }
 
   return {
@@ -117,7 +129,6 @@ export function createReplicationEngine(deps: ReplicationEngineDeps): Replicatio
       }
 
       const hlc = nextHlc({ lastHlc, wallClockMs: clock(), peerIdShort });
-      lastHlc = hlc;
 
       const payload: Op['payload'] = {};
       if (args.opType !== 'delete') {
@@ -155,13 +166,14 @@ export function createReplicationEngine(deps: ReplicationEngineDeps): Replicatio
             })),
           );
         }
+        lastHlc = hlc; // advance only on successful commit
       });
 
       for (const l of localOpListeners) {
         try {
           l(op);
         } catch (err) {
-          console.error('localOpListener threw', err);
+          serviceLogger.error({ err }, 'peers.replication.localOpListener threw');
         }
       }
 

--- a/src/main/features/peers/schema.ts
+++ b/src/main/features/peers/schema.ts
@@ -1,0 +1,37 @@
+import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+
+export const opLog = sqliteTable(
+  'op_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    hlc: text('hlc').notNull(),
+    originPeerId: text('origin_peer_id').notNull(),
+    tableName: text('table_name').notNull(),
+    pk: text('pk').notNull(),
+    opType: text('op_type', { enum: ['insert', 'update', 'delete'] }).notNull(),
+    payload: text('payload').notNull(),
+    appliedAt: integer('applied_at').notNull(),
+  },
+  (t) => [
+    index('op_log_peer_hlc').on(t.originPeerId, t.hlc),
+    uniqueIndex('op_log_dedup').on(t.originPeerId, t.hlc),
+  ],
+);
+
+export const rowMeta = sqliteTable(
+  'row_meta',
+  {
+    tableName: text('table_name').notNull(),
+    pk: text('pk').notNull(),
+    columnName: text('column_name').notNull(),
+    hlc: text('hlc').notNull(),
+    originPeerId: text('origin_peer_id').notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.tableName, t.pk, t.columnName] }),
+    index('row_meta_by_row').on(t.tableName, t.pk),
+  ],
+);
+
+export type OpLogRow = typeof opLog.$inferSelect;
+export type RowMetaRow = typeof rowMeta.$inferSelect;

--- a/src/main/features/peers/schema.ts
+++ b/src/main/features/peers/schema.ts
@@ -13,7 +13,6 @@ export const opLog = sqliteTable(
     appliedAt: integer('applied_at').notNull(),
   },
   (t) => [
-    index('op_log_peer_hlc').on(t.originPeerId, t.hlc),
     uniqueIndex('op_log_dedup').on(t.originPeerId, t.hlc),
   ],
 );

--- a/src/main/features/peers/ws-transport.ts
+++ b/src/main/features/peers/ws-transport.ts
@@ -1,0 +1,128 @@
+import { WebSocket, WebSocketServer, type RawData } from 'ws';
+
+import type { Op } from '@shared/replication/op-types';
+
+import type { ReplicationEngine } from '@main/features/peers/replication-engine';
+import { serviceLogger } from '@main/lib/logger';
+
+
+export interface WsTransportDeps {
+  engine: ReplicationEngine;
+  listenPort: number; // 0 = OS-assigned
+  remoteUrl: string;  // '' = don't connect out
+}
+
+export interface WsTransport {
+  listenPort: () => number;
+  isConnected: () => boolean;
+  close: () => Promise<void>;
+}
+
+interface WireFrame {
+  type: 'HELLO' | 'OPS' | 'PING';
+  payload?: unknown;
+}
+
+function dataToString(data: RawData): string {
+  if (typeof data === 'string') return data;
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return Buffer.from(data).toString('utf8');
+}
+
+export async function createWsTransport(deps: WsTransportDeps): Promise<WsTransport> {
+  const { engine, remoteUrl } = deps;
+
+  let outSocket: WebSocket | null = null;
+  const incomingSockets = new Set<WebSocket>();
+
+  const wss = new WebSocketServer({ port: deps.listenPort, host: '127.0.0.1' });
+  await new Promise<void>((resolve) => {
+    wss.once('listening', () => { resolve(); });
+  });
+  const addr = wss.address();
+  if (addr === null || typeof addr === 'string') {
+    throw new Error('WebSocketServer returned unexpected address');
+  }
+  const actualPort = addr.port;
+
+  function send(ws: WebSocket, frame: WireFrame): void {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(frame));
+    }
+  }
+
+  function broadcastOp(op: Op): void {
+    const frame: WireFrame = { type: 'OPS', payload: { ops: [op] } };
+    const str = JSON.stringify(frame);
+    if (outSocket?.readyState === WebSocket.OPEN) outSocket.send(str);
+    for (const ws of incomingSockets) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(str);
+    }
+  }
+
+  function handleFrame(raw: string): void {
+    let frame: WireFrame;
+    try {
+      frame = JSON.parse(raw) as WireFrame;
+    } catch {
+      return;
+    }
+    if (frame.type === 'OPS') {
+      const { ops } = (frame.payload ?? { ops: [] }) as { ops: Op[] };
+      for (const op of ops) {
+        try {
+          engine.applyRemoteOp(op);
+        } catch (err) {
+          serviceLogger.error({ err }, 'peers.wsTransport.applyRemoteOp threw');
+        }
+      }
+    }
+    // HELLO and PING are no-ops in Phase 1
+  }
+
+  wss.on('connection', (ws) => {
+    incomingSockets.add(ws);
+    ws.on('message', (data: RawData) => handleFrame(dataToString(data)));
+    ws.on('close', () => incomingSockets.delete(ws));
+    send(ws, { type: 'HELLO' });
+  });
+
+  let shuttingDown = false;
+  function dial(): void {
+    if (!remoteUrl || shuttingDown) return;
+    const ws = new WebSocket(remoteUrl);
+    outSocket = ws;
+    ws.on('open', () => {
+      send(ws, { type: 'HELLO' });
+    });
+    ws.on('message', (data: RawData) => handleFrame(dataToString(data)));
+    ws.on('close', () => {
+      outSocket = null;
+      if (!shuttingDown) {
+        setTimeout(dial, 1000);
+      }
+    });
+    ws.on('error', (err) => {
+      serviceLogger.warn({ err }, 'peers.wsTransport.dial error');
+    });
+  }
+  if (remoteUrl) dial();
+
+  const unsubscribe = engine.onLocalOp((op) => broadcastOp(op));
+
+  return {
+    listenPort: () => actualPort,
+    isConnected: () =>
+      outSocket?.readyState === WebSocket.OPEN || incomingSockets.size > 0,
+    async close() {
+      shuttingDown = true;
+      unsubscribe();
+      if (outSocket) outSocket.close();
+      for (const ws of incomingSockets) ws.close();
+      await new Promise<void>((resolve) => {
+        wss.close(() => { resolve(); });
+      });
+    },
+  };
+}

--- a/src/main/features/progress/progress-service.ts
+++ b/src/main/features/progress/progress-service.ts
@@ -21,6 +21,7 @@ import type { ProgressPriority, ProgressStatus, ProgressTask } from '@shared/typ
 
 import type { AdcDatabase } from '@main/db';
 import { progressTasks } from '@main/db/schema';
+import type { ReplicationEngine } from '@main/features/peers/replication-engine';
 import { serviceLogger } from '@main/lib/logger';
 
 import { runLogCleanup as runLogCleanupFn } from './log-cleanup';
@@ -28,6 +29,43 @@ import { detectRootFile, readFrontmatter, writeFrontmatter } from './task-file-i
 
 import type { AgentManager } from '../../agent-host/agent-host-client';
 import type { FSWatcher } from 'node:fs';
+
+// ─── Replication column-name mapping (camelCase TS → snake_case SQL) ─
+
+const PROGRESS_TASK_COLUMN_MAP: Record<string, string> = {
+  slug: 'slug',
+  id: 'id',
+  projectId: 'project_id',
+  title: 'title',
+  status: 'status',
+  priority: 'priority',
+  description: 'description',
+  jiraKey: 'jira_key',
+  jiraUrl: 'jira_url',
+  prUrl: 'pr_url',
+  prNumber: 'pr_number',
+  prStatus: 'pr_status',
+  lastSessionId: 'last_session_id',
+  lastAgentName: 'last_agent_name',
+  completedAt: 'completed_at',
+  archivedAt: 'archived_at',
+  teamName: 'team_name',
+  workflow: 'workflow',
+  workflowPhase: 'workflow_phase',
+  sessionHistory: 'session_history',
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
+};
+
+function toSnakeColumns(camelColumns: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(camelColumns)) {
+    if (Object.hasOwn(PROGRESS_TASK_COLUMN_MAP, k)) {
+      out[PROGRESS_TASK_COLUMN_MAP[k]] = v;
+    }
+  }
+  return out;
+}
 
 // ─── Service Interface ────────────────────────────────────────
 
@@ -466,6 +504,7 @@ export function createProgressService(
   projectPath: string,
   agentManagerService: AgentManager,
   db: AdcDatabase,
+  replicationEngine?: ReplicationEngine,
 ): ProgressService {
   const progressDir = join(projectPath, 'progress');
   const archivedDir = join(progressDir, 'archived');
@@ -847,6 +886,23 @@ export function createProgressService(
         updatedAt: now,
       }).run();
 
+      replicationEngine?.recordLocalWrite({
+        tableName: 'progress_tasks',
+        pk: slug,
+        opType: 'insert',
+        columns: toSnakeColumns({
+          slug,
+          id: resolvedId,
+          projectId: projectId ?? null,
+          title,
+          status: 'backlog',
+          priority,
+          description: description || null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      });
+
       // 2. Create filesystem directory + markdown file
       const taskDir = join(progressDir, slug);
       await mkdir(taskDir, { recursive: true });
@@ -937,6 +993,13 @@ export function createProgressService(
         .where(eq(progressTasks.slug, slug))
         .run();
 
+      replicationEngine?.recordLocalWrite({
+        tableName: 'progress_tasks',
+        pk: slug,
+        opType: 'update',
+        columns: toSnakeColumns(dbUpdates),
+      });
+
       // 2. Also rewrite frontmatter so filesystem stays in sync
       const taskDir = join(progressDir, slug);
       const rootFileName = await detectRootFile(taskDir);
@@ -978,6 +1041,13 @@ export function createProgressService(
         .where(eq(progressTasks.slug, slug))
         .run();
 
+      replicationEngine?.recordLocalWrite({
+        tableName: 'progress_tasks',
+        pk: slug,
+        opType: 'update',
+        columns: toSnakeColumns({ status: 'archived', archivedAt: now, updatedAt: now }),
+      });
+
       // 2. Stamp frontmatter and move directory
       await mkdir(archivedDir, { recursive: true });
       const src = join(progressDir, slug);
@@ -1007,6 +1077,13 @@ export function createProgressService(
       db.delete(progressTasks)
         .where(eq(progressTasks.slug, slug))
         .run();
+
+      replicationEngine?.recordLocalWrite({
+        tableName: 'progress_tasks',
+        pk: slug,
+        opType: 'delete',
+        columns: {},
+      });
 
       // 2. Remove filesystem directory
       const taskDir = join(progressDir, slug);

--- a/src/shared/replication/hlc.ts
+++ b/src/shared/replication/hlc.ts
@@ -5,7 +5,7 @@ export interface Hlc {
 }
 
 const WALL_PAD = 20;
-const COUNTER_PAD = 4;
+const COUNTER_PAD = 8;
 
 export function formatHlc(hlc: Hlc): string {
   const wall = String(hlc.wallClockMs).padStart(WALL_PAD, '0');
@@ -18,11 +18,12 @@ export function parseHlc(s: string): Hlc {
   if (parts.length !== 3) {
     throw new Error(`invalid HLC: ${s}`);
   }
-  return {
-    wallClockMs: Number(parts[0]),
-    counter: parseInt(parts[1], 16),
-    peerIdShort: parts[2],
-  };
+  const wallClockMs = Number(parts[0]);
+  const counter = parseInt(parts[1], 16);
+  if (!Number.isFinite(wallClockMs) || !Number.isFinite(counter)) {
+    throw new Error(`invalid HLC: ${s}`);
+  }
+  return { wallClockMs, counter, peerIdShort: parts[2] };
 }
 
 export function compareHlc(a: string, b: string): number {

--- a/src/shared/replication/hlc.ts
+++ b/src/shared/replication/hlc.ts
@@ -1,0 +1,62 @@
+export interface Hlc {
+  wallClockMs: number;
+  counter: number;
+  peerIdShort: string;
+}
+
+const WALL_PAD = 20;
+const COUNTER_PAD = 4;
+
+export function formatHlc(hlc: Hlc): string {
+  const wall = String(hlc.wallClockMs).padStart(WALL_PAD, '0');
+  const counter = hlc.counter.toString(16).padStart(COUNTER_PAD, '0');
+  return `${wall}.${counter}.${hlc.peerIdShort}`;
+}
+
+export function parseHlc(s: string): Hlc {
+  const parts = s.split('.');
+  if (parts.length !== 3) {
+    throw new Error(`invalid HLC: ${s}`);
+  }
+  return {
+    wallClockMs: Number(parts[0]),
+    counter: parseInt(parts[1], 16),
+    peerIdShort: parts[2],
+  };
+}
+
+export function compareHlc(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export function nextHlc(args: {
+  lastHlc: string | null;
+  wallClockMs: number;
+  peerIdShort: string;
+}): string {
+  const { lastHlc, wallClockMs, peerIdShort } = args;
+
+  if (lastHlc === null) {
+    return formatHlc({ wallClockMs, counter: 0, peerIdShort });
+  }
+
+  const last = parseHlc(lastHlc);
+
+  if (wallClockMs > last.wallClockMs) {
+    return formatHlc({ wallClockMs, counter: 0, peerIdShort });
+  }
+
+  // Clock did not advance (or went backward). Bump counter.
+  return formatHlc({
+    wallClockMs: last.wallClockMs,
+    counter: last.counter + 1,
+    peerIdShort,
+  });
+}
+
+export function receiveHlc(local: string | null, incoming: string): string {
+  if (local === null) return incoming;
+  return compareHlc(local, incoming) >= 0 ? local : incoming;
+}

--- a/src/shared/replication/op-types.ts
+++ b/src/shared/replication/op-types.ts
@@ -1,0 +1,23 @@
+import type { SyncTable } from './sync-tables';
+
+export type OpType = 'insert' | 'update' | 'delete';
+
+export interface ColumnValue {
+  value: unknown;
+  hlc: string;
+}
+
+export interface Op {
+  hlc: string;
+  originPeerId: string;
+  tableName: SyncTable;
+  pk: string;
+  opType: OpType;
+  /**
+   * For insert/update: every mutated column with its value and HLC.
+   * For delete: empty object; the tombstone lives in `row_meta` via column `__deleted__`.
+   */
+  payload: Record<string, ColumnValue>;
+}
+
+export const TOMBSTONE_COLUMN = '__deleted__';

--- a/src/shared/replication/sync-tables.ts
+++ b/src/shared/replication/sync-tables.ts
@@ -5,3 +5,9 @@ export type SyncTable = typeof SYNC_TABLES[number];
 export function isSyncTable(name: string): name is SyncTable {
   return (SYNC_TABLES as readonly string[]).includes(name);
 }
+
+/** Maps each sync table to its primary-key column. Used by the replication engine
+ *  to write `ON CONFLICT(pk) DO UPDATE` and `WHERE pk = ?` clauses. */
+export const SYNC_TABLE_PK: Record<SyncTable, string> = {
+  progress_tasks: 'slug',
+};

--- a/src/shared/replication/sync-tables.ts
+++ b/src/shared/replication/sync-tables.ts
@@ -1,0 +1,7 @@
+export const SYNC_TABLES = ['progress_tasks'] as const;
+
+export type SyncTable = typeof SYNC_TABLES[number];
+
+export function isSyncTable(name: string): name is SyncTable {
+  return (SYNC_TABLES as readonly string[]).includes(name);
+}

--- a/tests/integration/peers/convergence.test.ts
+++ b/tests/integration/peers/convergence.test.ts
@@ -1,13 +1,15 @@
 // tests/integration/peers/convergence.test.ts
+import { resolve } from 'node:path';
+
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { Op } from '@shared/replication/op-types';
 
 import * as schema from '@main/db/schema';
 import { createReplicationEngine, type ReplicationEngine } from '@main/features/peers/replication-engine';
-import type { Op } from '@shared/replication/op-types';
 
 interface Peer {
   sqlite: Database.Database;

--- a/tests/integration/peers/convergence.test.ts
+++ b/tests/integration/peers/convergence.test.ts
@@ -1,0 +1,231 @@
+// tests/integration/peers/convergence.test.ts
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as schema from '@main/db/schema';
+import { createReplicationEngine, type ReplicationEngine } from '@main/features/peers/replication-engine';
+import type { Op } from '@shared/replication/op-types';
+
+interface Peer {
+  sqlite: Database.Database;
+  db: ReturnType<typeof drizzle<typeof schema>>;
+  engine: ReplicationEngine;
+  inbox: Op[];
+}
+
+function makePeer(peerIdShort: string, peerIdFull: string, clockRef: { now: number }): Peer {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+  const engine = createReplicationEngine({
+    db,
+    peerIdShort,
+    peerIdFull,
+    clock: () => clockRef.now,
+  });
+  return { sqlite, db, engine, inbox: [] };
+}
+
+function wireBus(a: Peer, b: Peer): { disconnect: () => void; reconnect: () => void } {
+  let connected = true;
+  a.engine.onLocalOp((op) => {
+    if (connected) b.inbox.push(op);
+  });
+  b.engine.onLocalOp((op) => {
+    if (connected) a.inbox.push(op);
+  });
+  return {
+    disconnect: () => { connected = false; },
+    reconnect: () => { connected = true; },
+  };
+}
+
+function drain(peer: Peer): void {
+  while (peer.inbox.length > 0) {
+    const op = peer.inbox.shift()!;
+    peer.engine.applyRemoteOp(op);
+  }
+}
+
+function readTask(peer: Peer, slug: string): Record<string, unknown> | undefined {
+  return peer.sqlite.prepare(`SELECT * FROM progress_tasks WHERE slug=?`).get(slug) as
+    | Record<string, unknown>
+    | undefined;
+}
+
+function rowToOp(row: Record<string, unknown>): Op {
+  return {
+    hlc: row.hlc as string,
+    originPeerId: row.origin_peer_id as string,
+    tableName: row.table_name as Op['tableName'],
+    pk: row.pk as string,
+    opType: row.op_type as Op['opType'],
+    payload: JSON.parse(row.payload as string),
+  };
+}
+
+function localInsert(peer: Peer, slug: string, title: string): void {
+  // Simulate a service-layer insert: write to user table, then register op.
+  peer.sqlite
+    .prepare(
+      `INSERT INTO progress_tasks (slug, title, status, priority, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(slug, title, 'backlog', 'medium', '2026-04-24T00:00:00Z', '2026-04-24T00:00:00Z');
+
+  peer.engine.recordLocalWrite({
+    tableName: 'progress_tasks',
+    pk: slug,
+    opType: 'insert',
+    columns: {
+      slug,
+      title,
+      status: 'backlog',
+      priority: 'medium',
+      created_at: '2026-04-24T00:00:00Z',
+      updated_at: '2026-04-24T00:00:00Z',
+    },
+  });
+}
+
+function localUpdate(peer: Peer, slug: string, columns: Record<string, unknown>): void {
+  // Service would write to user table, then register op.
+  const cols = Object.keys(columns);
+  if (cols.length > 0) {
+    peer.sqlite
+      .prepare(
+        `UPDATE progress_tasks SET ${cols.map((c) => `"${c}"=?`).join(', ')} WHERE slug=?`,
+      )
+      .run(...cols.map((c) => columns[c]), slug);
+  }
+  peer.engine.recordLocalWrite({
+    tableName: 'progress_tasks',
+    pk: slug,
+    opType: 'update',
+    columns,
+  });
+}
+
+function localDelete(peer: Peer, slug: string): void {
+  peer.sqlite.prepare(`DELETE FROM progress_tasks WHERE slug=?`).run(slug);
+  peer.engine.recordLocalWrite({
+    tableName: 'progress_tasks',
+    pk: slug,
+    opType: 'delete',
+    columns: {},
+  });
+}
+
+describe('two-peer convergence', () => {
+  let clockRef: { now: number };
+  let A: Peer;
+  let B: Peer;
+  let bus: ReturnType<typeof wireBus>;
+
+  beforeEach(() => {
+    clockRef = { now: 1_000_000_000 };
+    A = makePeer('aaaaaaaa', 'peer-a', clockRef);
+    B = makePeer('bbbbbbbb', 'peer-b', clockRef);
+    bus = wireBus(A, B);
+  });
+
+  afterEach(() => {
+    A.sqlite.close();
+    B.sqlite.close();
+  });
+
+  it('insert on A appears on B', () => {
+    localInsert(A, 'task-1', 'Hello');
+    drain(B);
+    const onB = readTask(B, 'task-1');
+    expect(onB?.title).toBe('Hello');
+  });
+
+  it('converges after partition — disjoint writes', () => {
+    bus.disconnect();
+    clockRef.now = 1_000_001;
+    localInsert(A, 'task-a', 'From A');
+    clockRef.now = 1_000_002;
+    localInsert(B, 'task-b', 'From B');
+    bus.reconnect();
+
+    // Pull-on-reconnect: replay each peer's local op_log to the other.
+    const aOps = A.sqlite.prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-a'`).all() as Array<Record<string, unknown>>;
+    const bOps = B.sqlite.prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-b'`).all() as Array<Record<string, unknown>>;
+    for (const row of aOps) B.engine.applyRemoteOp(rowToOp(row));
+    for (const row of bOps) A.engine.applyRemoteOp(rowToOp(row));
+
+    expect(readTask(A, 'task-a')?.title).toBe('From A');
+    expect(readTask(A, 'task-b')?.title).toBe('From B');
+    expect(readTask(B, 'task-a')?.title).toBe('From A');
+    expect(readTask(B, 'task-b')?.title).toBe('From B');
+  });
+
+  it('column-level LWW — different fields of same task edited on both', () => {
+    localInsert(A, 'task-1', 'Initial');
+    drain(B);
+
+    bus.disconnect();
+    clockRef.now = 2_000_000;
+    localUpdate(A, 'task-1', { title: 'A-title' });
+    clockRef.now = 2_000_001;
+    localUpdate(B, 'task-1', { status: 'executing' });
+    bus.reconnect();
+
+    const aOps = A.sqlite
+      .prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-a' AND pk='task-1'`)
+      .all() as Array<Record<string, unknown>>;
+    const bOps = B.sqlite
+      .prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-b' AND pk='task-1'`)
+      .all() as Array<Record<string, unknown>>;
+    for (const row of aOps) B.engine.applyRemoteOp(rowToOp(row));
+    for (const row of bOps) A.engine.applyRemoteOp(rowToOp(row));
+
+    const onA = readTask(A, 'task-1');
+    const onB = readTask(B, 'task-1');
+    expect(onA?.title).toBe('A-title');
+    expect(onA?.status).toBe('executing');
+    expect(onB?.title).toBe('A-title');
+    expect(onB?.status).toBe('executing');
+  });
+
+  it('delete wins over older update', () => {
+    localInsert(A, 'task-del', 'Doomed');
+    drain(B);
+
+    bus.disconnect();
+    clockRef.now = 3_000_000;
+    localUpdate(B, 'task-del', { title: 'B tried to update' });
+    clockRef.now = 3_000_001;
+    localDelete(A, 'task-del');
+    bus.reconnect();
+
+    const aOps = A.sqlite
+      .prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-a' AND pk='task-del'`)
+      .all() as Array<Record<string, unknown>>;
+    const bOps = B.sqlite
+      .prepare(`SELECT * FROM op_log WHERE origin_peer_id='peer-b' AND pk='task-del'`)
+      .all() as Array<Record<string, unknown>>;
+    for (const row of aOps) B.engine.applyRemoteOp(rowToOp(row));
+    for (const row of bOps) A.engine.applyRemoteOp(rowToOp(row));
+
+    expect(readTask(A, 'task-del')).toBeUndefined();
+    expect(readTask(B, 'task-del')).toBeUndefined();
+  });
+
+  it('duplicate op delivery is idempotent', () => {
+    localInsert(A, 'task-idem', 'Once');
+    drain(B);
+    const op = rowToOp(
+      A.sqlite.prepare(`SELECT * FROM op_log WHERE pk='task-idem'`).get() as Record<string, unknown>,
+    );
+    B.engine.applyRemoteOp(op);
+    B.engine.applyRemoteOp(op);
+
+    const count = B.sqlite.prepare(`SELECT COUNT(*) as c FROM op_log`).get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+});

--- a/tests/integration/peers/hlc.test.ts
+++ b/tests/integration/peers/hlc.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
 
 import {
   compareHlc,

--- a/tests/integration/peers/hlc.test.ts
+++ b/tests/integration/peers/hlc.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+
+import {
+  compareHlc,
+  formatHlc,
+  nextHlc,
+  parseHlc,
+  receiveHlc,
+  type Hlc,
+} from '@shared/replication/hlc';
+
+const PEER_A = 'aaaaaaaa';
+const PEER_B = 'bbbbbbbb';
+
+describe('formatHlc / parseHlc', () => {
+  it('round-trips', () => {
+    const h: Hlc = { wallClockMs: 1713955200000, counter: 42, peerIdShort: PEER_A };
+    expect(parseHlc(formatHlc(h))).toEqual(h);
+  });
+
+  it('pads counter to 4 hex digits', () => {
+    const s = formatHlc({ wallClockMs: 100, counter: 3, peerIdShort: PEER_A });
+    expect(s).toBe('00000000000000000100.0003.aaaaaaaa');
+  });
+
+  it('pads wallClockMs to 20 digits for lexicographic sort', () => {
+    const s = formatHlc({ wallClockMs: 1, counter: 0, peerIdShort: PEER_A });
+    expect(s.startsWith('00000000000000000001')).toBe(true);
+  });
+});
+
+describe('compareHlc', () => {
+  it('orders by wallClockMs first', () => {
+    const earlier = formatHlc({ wallClockMs: 100, counter: 999, peerIdShort: PEER_B });
+    const later = formatHlc({ wallClockMs: 101, counter: 0, peerIdShort: PEER_A });
+    expect(compareHlc(earlier, later)).toBeLessThan(0);
+  });
+
+  it('breaks ties by counter', () => {
+    const a = formatHlc({ wallClockMs: 100, counter: 1, peerIdShort: PEER_B });
+    const b = formatHlc({ wallClockMs: 100, counter: 2, peerIdShort: PEER_A });
+    expect(compareHlc(a, b)).toBeLessThan(0);
+  });
+
+  it('breaks counter ties by peerIdShort', () => {
+    const a = formatHlc({ wallClockMs: 100, counter: 1, peerIdShort: PEER_A });
+    const b = formatHlc({ wallClockMs: 100, counter: 1, peerIdShort: PEER_B });
+    expect(compareHlc(a, b)).toBeLessThan(0);
+  });
+
+  it('is a total order (property)', () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(fc.nat(1e12), fc.nat(100), fc.constantFrom(PEER_A, PEER_B)),
+        fc.tuple(fc.nat(1e12), fc.nat(100), fc.constantFrom(PEER_A, PEER_B)),
+        (ha, hb) => {
+          const a = formatHlc({ wallClockMs: ha[0], counter: ha[1], peerIdShort: ha[2] });
+          const b = formatHlc({ wallClockMs: hb[0], counter: hb[1], peerIdShort: hb[2] });
+          const cmp = compareHlc(a, b);
+          if (cmp === 0) return a === b;
+          if (cmp < 0) return compareHlc(b, a) > 0;
+          return compareHlc(b, a) < 0;
+        },
+      ),
+    );
+  });
+});
+
+describe('nextHlc', () => {
+  it('uses wallClock if greater than lastHlc', () => {
+    const last = formatHlc({ wallClockMs: 100, counter: 5, peerIdShort: PEER_A });
+    const next = nextHlc({ lastHlc: last, wallClockMs: 200, peerIdShort: PEER_A });
+    expect(parseHlc(next)).toEqual({ wallClockMs: 200, counter: 0, peerIdShort: PEER_A });
+  });
+
+  it('increments counter if wallClock has not advanced', () => {
+    const last = formatHlc({ wallClockMs: 100, counter: 5, peerIdShort: PEER_A });
+    const next = nextHlc({ lastHlc: last, wallClockMs: 100, peerIdShort: PEER_A });
+    expect(parseHlc(next)).toEqual({ wallClockMs: 100, counter: 6, peerIdShort: PEER_A });
+  });
+
+  it('increments counter if wallClock moves backward (clock skew)', () => {
+    const last = formatHlc({ wallClockMs: 100, counter: 5, peerIdShort: PEER_A });
+    const next = nextHlc({ lastHlc: last, wallClockMs: 50, peerIdShort: PEER_A });
+    expect(parseHlc(next)).toEqual({ wallClockMs: 100, counter: 6, peerIdShort: PEER_A });
+  });
+
+  it('produces strictly increasing HLCs even at identical wallClock', () => {
+    let last = formatHlc({ wallClockMs: 100, counter: 0, peerIdShort: PEER_A });
+    for (let i = 0; i < 1000; i++) {
+      const next = nextHlc({ lastHlc: last, wallClockMs: 100, peerIdShort: PEER_A });
+      expect(compareHlc(next, last)).toBeGreaterThan(0);
+      last = next;
+    }
+  });
+});
+
+describe('receiveHlc', () => {
+  it('advances lastHlc to max(lastHlc, incoming)', () => {
+    const local = formatHlc({ wallClockMs: 100, counter: 5, peerIdShort: PEER_A });
+    const remote = formatHlc({ wallClockMs: 200, counter: 0, peerIdShort: PEER_B });
+    expect(receiveHlc(local, remote)).toBe(remote);
+  });
+
+  it('keeps local if local is higher', () => {
+    const local = formatHlc({ wallClockMs: 300, counter: 0, peerIdShort: PEER_A });
+    const remote = formatHlc({ wallClockMs: 200, counter: 0, peerIdShort: PEER_B });
+    expect(receiveHlc(local, remote)).toBe(local);
+  });
+});

--- a/tests/integration/peers/hlc.test.ts
+++ b/tests/integration/peers/hlc.test.ts
@@ -19,14 +19,26 @@ describe('formatHlc / parseHlc', () => {
     expect(parseHlc(formatHlc(h))).toEqual(h);
   });
 
-  it('pads counter to 4 hex digits', () => {
+  it('pads counter to 8 hex digits', () => {
     const s = formatHlc({ wallClockMs: 100, counter: 3, peerIdShort: PEER_A });
-    expect(s).toBe('00000000000000000100.0003.aaaaaaaa');
+    expect(s).toBe('00000000000000000100.00000003.aaaaaaaa');
   });
 
   it('pads wallClockMs to 20 digits for lexicographic sort', () => {
     const s = formatHlc({ wallClockMs: 1, counter: 0, peerIdShort: PEER_A });
     expect(s.startsWith('00000000000000000001')).toBe(true);
+  });
+
+  it('handles large counters without changing width', () => {
+    const s = formatHlc({ wallClockMs: 100, counter: 0xFFFFFF, peerIdShort: 'aaaaaaaa' });
+    const parts = s.split('.');
+    expect(parts[1]).toHaveLength(8);
+    expect(parseInt(parts[1], 16)).toBe(0xFFFFFF);
+  });
+
+  it('throws on non-numeric parts', () => {
+    expect(() => parseHlc('abc.0000.aaaaaaaa')).toThrow(/invalid HLC/);
+    expect(() => parseHlc('100.zz.aaaaaaaa')).toThrow(/invalid HLC/);
   });
 });
 
@@ -86,11 +98,24 @@ describe('nextHlc', () => {
     expect(parseHlc(next)).toEqual({ wallClockMs: 100, counter: 6, peerIdShort: PEER_A });
   });
 
-  it('produces strictly increasing HLCs even at identical wallClock', () => {
+  it('produces strictly increasing HLCs across constant wallClock', () => {
     let last = formatHlc({ wallClockMs: 100, counter: 0, peerIdShort: PEER_A });
     for (let i = 0; i < 1000; i++) {
       const next = nextHlc({ lastHlc: last, wallClockMs: 100, peerIdShort: PEER_A });
       expect(compareHlc(next, last)).toBeGreaterThan(0);
+      last = next;
+    }
+  });
+
+  it('produces strictly increasing HLCs across advancing and retreating wallClock', () => {
+    const pattern = [100, 101, 101, 100, 50, 102, 102, 200, 199, 1000];
+    let last: string | null = null;
+    for (let i = 0; i < 200; i++) {
+      const wallClockMs = pattern[i % pattern.length];
+      const next = nextHlc({ lastHlc: last, wallClockMs, peerIdShort: PEER_A });
+      if (last !== null) {
+        expect(compareHlc(next, last)).toBeGreaterThan(0);
+      }
       last = next;
     }
   });

--- a/tests/integration/peers/lww-merge.test.ts
+++ b/tests/integration/peers/lww-merge.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
+import type { Op } from '@shared/replication/op-types';
+import { TOMBSTONE_COLUMN } from '@shared/replication/op-types';
+
+const HLC_1 = '00000000000000000001.00000000.aaaaaaaa';
+const HLC_2 = '00000000000000000002.00000000.bbbbbbbb';
+const HLC_3 = '00000000000000000003.00000000.aaaaaaaa';
+
+function op(overrides: Partial<Op> = {}): Op {
+  return {
+    hlc: HLC_2,
+    originPeerId: 'peer-b',
+    tableName: 'progress_tasks',
+    pk: 'task-1',
+    opType: 'update',
+    payload: { title: { value: 'New', hlc: HLC_2 } },
+    ...overrides,
+  };
+}
+
+describe('mergeOp', () => {
+  it('applies insert when no local row_meta exists', () => {
+    const result = mergeOp({}, op({ opType: 'insert' }));
+    expect(result.columnsToApply).toEqual({ title: 'New' });
+    expect(result.rowMetaUpdates).toEqual([
+      { columnName: 'title', hlc: HLC_2, originPeerId: 'peer-b' },
+    ]);
+    expect(result.tombstone).toBe(false);
+  });
+
+  it('skips a column when incoming hlc is older than local', () => {
+    const meta: RowMetaState = { title: { hlc: HLC_3, originPeerId: 'peer-a' } };
+    const result = mergeOp(meta, op({ hlc: HLC_2, payload: { title: { value: 'Old', hlc: HLC_2 } } }));
+    expect(result.columnsToApply).toEqual({});
+    expect(result.rowMetaUpdates).toEqual([]);
+  });
+
+  it('applies a column when incoming hlc is newer', () => {
+    const meta: RowMetaState = { title: { hlc: HLC_1, originPeerId: 'peer-a' } };
+    const result = mergeOp(meta, op({ hlc: HLC_2 }));
+    expect(result.columnsToApply).toEqual({ title: 'New' });
+    expect(result.rowMetaUpdates).toHaveLength(1);
+  });
+
+  it('merges per-column — different columns compared independently', () => {
+    const meta: RowMetaState = {
+      title: { hlc: HLC_3, originPeerId: 'peer-a' },
+      status: { hlc: HLC_1, originPeerId: 'peer-a' },
+    };
+    const result = mergeOp(
+      meta,
+      op({
+        hlc: HLC_2,
+        payload: {
+          title: { value: 'Loses', hlc: HLC_2 },
+          status: { value: 'Wins', hlc: HLC_2 },
+        },
+      }),
+    );
+    expect(result.columnsToApply).toEqual({ status: 'Wins' });
+    expect(result.rowMetaUpdates.map((u) => u.columnName)).toEqual(['status']);
+  });
+
+  it('emits tombstone for delete op', () => {
+    const result = mergeOp({}, op({ opType: 'delete', payload: {}, hlc: HLC_3 }));
+    expect(result.tombstone).toBe(true);
+    expect(result.rowMetaUpdates).toEqual([
+      { columnName: TOMBSTONE_COLUMN, hlc: HLC_3, originPeerId: 'peer-b' },
+    ]);
+  });
+
+  it('does not apply update if row is tombstoned with higher hlc', () => {
+    const meta: RowMetaState = {
+      [TOMBSTONE_COLUMN]: { hlc: HLC_3, originPeerId: 'peer-a' },
+    };
+    const result = mergeOp(meta, op({ hlc: HLC_2 }));
+    expect(result.columnsToApply).toEqual({});
+    expect(result.tombstone).toBe(false);
+    expect(result.rowMetaUpdates).toEqual([]);
+  });
+
+  it('resurrects row if update hlc is higher than tombstone hlc', () => {
+    const meta: RowMetaState = {
+      [TOMBSTONE_COLUMN]: { hlc: HLC_1, originPeerId: 'peer-a' },
+    };
+    const result = mergeOp(meta, op({ hlc: HLC_2 }));
+    expect(result.columnsToApply).toEqual({ title: 'New' });
+    expect(result.resurrectTombstone).toBe(true);
+  });
+
+  it('is idempotent — applying same op twice is a no-op the second time', () => {
+    const meta: RowMetaState = {};
+    const firstOp = op({ hlc: HLC_2, opType: 'insert' });
+    const first = mergeOp(meta, firstOp);
+
+    const metaAfter: RowMetaState = {};
+    for (const u of first.rowMetaUpdates) {
+      metaAfter[u.columnName] = { hlc: u.hlc, originPeerId: u.originPeerId };
+    }
+
+    const second = mergeOp(metaAfter, firstOp);
+    expect(second.columnsToApply).toEqual({});
+    expect(second.rowMetaUpdates).toEqual([]);
+  });
+});

--- a/tests/integration/peers/lww-merge.test.ts
+++ b/tests/integration/peers/lww-merge.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
 import type { Op } from '@shared/replication/op-types';
 import { TOMBSTONE_COLUMN } from '@shared/replication/op-types';
+
+import { mergeOp, type RowMetaState } from '@main/features/peers/lww-merge';
 
 const HLC_1 = '00000000000000000001.00000000.aaaaaaaa';
 const HLC_2 = '00000000000000000002.00000000.bbbbbbbb';

--- a/tests/integration/peers/op-log.test.ts
+++ b/tests/integration/peers/op-log.test.ts
@@ -1,12 +1,14 @@
+import { resolve } from 'node:path';
+
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { Op } from '@shared/replication/op-types';
 
 import * as schema from '@main/db/schema';
 import { createOpLogService } from '@main/features/peers/op-log';
-import type { Op } from '@shared/replication/op-types';
 
 let sqlite: Database.Database;
 let db: ReturnType<typeof drizzle<typeof schema>>;

--- a/tests/integration/peers/op-log.test.ts
+++ b/tests/integration/peers/op-log.test.ts
@@ -4,16 +4,17 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import * as schema from '@main/db/schema';
 import { createOpLogService } from '@main/features/peers/op-log';
 import type { Op } from '@shared/replication/op-types';
 
 let sqlite: Database.Database;
-let db: ReturnType<typeof drizzle>;
+let db: ReturnType<typeof drizzle<typeof schema>>;
 let opLog: ReturnType<typeof createOpLogService>;
 
 beforeEach(() => {
   sqlite = new Database(':memory:');
-  db = drizzle(sqlite);
+  db = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
   opLog = createOpLogService(db);
 });

--- a/tests/integration/peers/op-log.test.ts
+++ b/tests/integration/peers/op-log.test.ts
@@ -1,0 +1,85 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createOpLogService } from '@main/features/peers/op-log';
+import type { Op } from '@shared/replication/op-types';
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle>;
+let opLog: ReturnType<typeof createOpLogService>;
+
+beforeEach(() => {
+  sqlite = new Database(':memory:');
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+  opLog = createOpLogService(db);
+});
+
+afterEach(() => sqlite.close());
+
+const op = (overrides: Partial<Op> = {}): Op => ({
+  hlc: '00000000000000000001.00000000.aaaaaaaa',
+  originPeerId: 'peer-a',
+  tableName: 'progress_tasks',
+  pk: 'task-1',
+  opType: 'insert',
+  payload: { title: { value: 'First', hlc: '00000000000000000001.00000000.aaaaaaaa' } },
+  ...overrides,
+});
+
+describe('OpLogService.append', () => {
+  it('persists an op', () => {
+    opLog.append(op());
+    const all = opLog.readSince('peer-a', null);
+    expect(all).toHaveLength(1);
+    expect(all[0].hlc).toBe('00000000000000000001.00000000.aaaaaaaa');
+  });
+
+  it('is idempotent on (origin_peer_id, hlc) duplicates', () => {
+    opLog.append(op());
+    opLog.append(op());
+    const all = opLog.readSince('peer-a', null);
+    expect(all).toHaveLength(1);
+  });
+
+  it('stores payload as parseable JSON', () => {
+    opLog.append(op());
+    const [row] = opLog.readSince('peer-a', null);
+    expect(row.payload).toEqual({
+      title: { value: 'First', hlc: '00000000000000000001.00000000.aaaaaaaa' },
+    });
+  });
+});
+
+describe('OpLogService.readSince', () => {
+  it('returns ops with hlc > sinceHlc, ordered ascending', () => {
+    opLog.append(op({ hlc: '00000000000000000001.00000000.aaaaaaaa' }));
+    opLog.append(op({ hlc: '00000000000000000002.00000000.aaaaaaaa' }));
+    opLog.append(op({ hlc: '00000000000000000003.00000000.aaaaaaaa' }));
+    const result = opLog.readSince('peer-a', '00000000000000000001.00000000.aaaaaaaa');
+    expect(result.map((r) => r.hlc)).toEqual([
+      '00000000000000000002.00000000.aaaaaaaa',
+      '00000000000000000003.00000000.aaaaaaaa',
+    ]);
+  });
+
+  it('returns empty when sinceHlc is highest', () => {
+    opLog.append(op({ hlc: '00000000000000000001.00000000.aaaaaaaa' }));
+    const result = opLog.readSince('peer-a', '00000000000000000001.00000000.aaaaaaaa');
+    expect(result).toEqual([]);
+  });
+
+  it('filters by originPeerId', () => {
+    opLog.append(op({ originPeerId: 'peer-a', hlc: '00000000000000000001.00000000.aaaaaaaa' }));
+    opLog.append(op({ originPeerId: 'peer-b', hlc: '00000000000000000002.00000000.bbbbbbbb' }));
+    const a = opLog.readSince('peer-a', null);
+    const b = opLog.readSince('peer-b', null);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+    expect(a[0].originPeerId).toBe('peer-a');
+    expect(b[0].originPeerId).toBe('peer-b');
+  });
+});

--- a/tests/integration/peers/progress-service-replicates.test.ts
+++ b/tests/integration/peers/progress-service-replicates.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Op } from '@shared/replication/op-types';
+
+import type { AgentManager } from '@main/agent-host/agent-host-client';
+import * as schema from '@main/db/schema';
+import { createReplicationEngine } from '@main/features/peers/replication-engine';
+import { createProgressService } from '@main/features/progress/progress-service';
+
+describe('progress-service <-> replication-engine', () => {
+  let sqlite: Database.Database;
+  let db: ReturnType<typeof drizzle<typeof schema>>;
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    sqlite = new Database(':memory:');
+    db = drizzle(sqlite, { schema });
+    migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+    tmpRoot = await mkdtemp(join(tmpdir(), 'adc-progress-test-'));
+  });
+
+  afterEach(async () => {
+    sqlite.close();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('createTask records an insert op', async () => {
+    const engine = createReplicationEngine({
+      db,
+      peerIdShort: 'aaaaaaaa',
+      peerIdFull: 'peer-a',
+    });
+    const spy = vi.fn<(op: Op) => void>();
+    engine.onLocalOp(spy);
+
+    const service = createProgressService(
+      tmpRoot,
+      // agentHostClient is not used by createTask; cast for test-only stub
+      {} as AgentManager,
+      db,
+      engine,
+    );
+
+    await service.createTask('plan-xyz', 'Test plan', 'desc', 'normal');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const op = spy.mock.calls[0][0];
+    expect(op.opType).toBe('insert');
+    expect(op.pk).toBe('plan-xyz');
+    expect(op.tableName).toBe('progress_tasks');
+    expect(op.payload.title.value).toBe('Test plan');
+    expect(op.payload.slug.value).toBe('plan-xyz');
+    expect(op.payload.status.value).toBe('backlog');
+  });
+
+  it('updateTask records an update op with snake_case columns', async () => {
+    const engine = createReplicationEngine({
+      db,
+      peerIdShort: 'aaaaaaaa',
+      peerIdFull: 'peer-a',
+    });
+
+    const service = createProgressService(tmpRoot, {} as AgentManager, db, engine);
+    await service.createTask('plan-upd', 'Original', '', 'normal');
+
+    const spy = vi.fn<(op: Op) => void>();
+    engine.onLocalOp(spy);
+
+    await service.updateTask('plan-upd', { title: 'Renamed', status: 'executing' });
+
+    expect(spy).toHaveBeenCalledOnce();
+    const op = spy.mock.calls[0][0];
+    expect(op.opType).toBe('update');
+    expect(op.pk).toBe('plan-upd');
+    expect(op.payload.title.value).toBe('Renamed');
+    expect(op.payload.status.value).toBe('executing');
+    expect(op.payload.updated_at).toBeDefined();
+  });
+
+  it('deleteTask records a delete op', async () => {
+    const engine = createReplicationEngine({
+      db,
+      peerIdShort: 'aaaaaaaa',
+      peerIdFull: 'peer-a',
+    });
+
+    const service = createProgressService(tmpRoot, {} as AgentManager, db, engine);
+    await service.createTask('plan-del', 'To delete', '', 'normal');
+
+    const spy = vi.fn<(op: Op) => void>();
+    engine.onLocalOp(spy);
+
+    await service.deleteTask('plan-del');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const op = spy.mock.calls[0][0];
+    expect(op.opType).toBe('delete');
+    expect(op.pk).toBe('plan-del');
+    expect(op.payload).toEqual({});
+  });
+});

--- a/tests/integration/peers/replication-engine.test.ts
+++ b/tests/integration/peers/replication-engine.test.ts
@@ -1,0 +1,183 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as schema from '@main/db/schema';
+import { createReplicationEngine, type ReplicationEngine } from '@main/features/peers/replication-engine';
+import type { Op } from '@shared/replication/op-types';
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+let engine: ReplicationEngine;
+
+beforeEach(() => {
+  sqlite = new Database(':memory:');
+  db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+  engine = createReplicationEngine({
+    db,
+    peerIdShort: 'aaaaaaaa',
+    peerIdFull: 'peer-a',
+    clock: () => 1_000,
+  });
+});
+
+afterEach(() => sqlite.close());
+
+describe('ReplicationEngine.recordLocalWrite', () => {
+  it('appends an op with freshly-minted HLC', () => {
+    const op = engine.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-1',
+      opType: 'insert',
+      columns: { title: 'First', status: 'backlog' },
+    });
+
+    expect(op.originPeerId).toBe('peer-a');
+    expect(op.hlc).toMatch(/\.aaaaaaaa$/);
+    expect(op.payload.title.value).toBe('First');
+    expect(op.payload.status.value).toBe('backlog');
+    expect(op.payload.title.hlc).toBe(op.hlc);
+  });
+
+  it('writes row_meta entries for every mutated column', () => {
+    engine.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-1',
+      opType: 'insert',
+      columns: { title: 'X', status: 'backlog' },
+    });
+    const metas = sqlite
+      .prepare(`SELECT column_name FROM row_meta WHERE table_name='progress_tasks' AND pk='task-1'`)
+      .all() as Array<{ column_name: string }>;
+    expect(metas.map((m) => m.column_name).sort()).toEqual(['status', 'title']);
+  });
+});
+
+describe('ReplicationEngine.applyRemoteOp', () => {
+  function seedTask(slug: string) {
+    sqlite
+      .prepare(
+        `INSERT INTO progress_tasks (slug, title, status, priority, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(slug, 'Seed', 'backlog', 'medium', '2026-04-24T00:00:00Z', '2026-04-24T00:00:00Z');
+  }
+
+  it('applies an incoming insert op to progress_tasks', () => {
+    const op: Op = {
+      hlc: '00000000000000099999.00000000.bbbbbbbb',
+      originPeerId: 'peer-b',
+      tableName: 'progress_tasks',
+      pk: 'task-remote',
+      opType: 'insert',
+      payload: {
+        slug: { value: 'task-remote', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        title: { value: 'Remote', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        status: { value: 'backlog', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        priority: { value: 'medium', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        created_at: { value: '2026-04-24T00:00:00Z', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        updated_at: { value: '2026-04-24T00:00:00Z', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+      },
+    };
+
+    engine.applyRemoteOp(op);
+
+    const row = sqlite.prepare(`SELECT * FROM progress_tasks WHERE slug='task-remote'`).get();
+    expect(row).toBeDefined();
+    expect((row as { title: string }).title).toBe('Remote');
+  });
+
+  it('applies an incoming update with column-level LWW', () => {
+    // Peer A wrote locally: title='Local-title', status='backlog'. Stamp row_meta via recordLocalWrite.
+    sqlite
+      .prepare(
+        `INSERT INTO progress_tasks (slug, title, status, priority, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run('task-1', 'Local-title', 'backlog', 'medium', '2026-04-24T00:00:00Z', '2026-04-24T00:00:00Z');
+
+    engine.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-1',
+      opType: 'update',
+      columns: { title: 'Local-title', status: 'backlog' },
+    });
+
+    const incoming: Op = {
+      hlc: '00000000000009999999.00000000.bbbbbbbb',
+      originPeerId: 'peer-b',
+      tableName: 'progress_tasks',
+      pk: 'task-1',
+      opType: 'update',
+      payload: {
+        status: { value: 'executing', hlc: '00000000000009999999.00000000.bbbbbbbb' },
+      },
+    };
+
+    engine.applyRemoteOp(incoming);
+
+    const row = sqlite.prepare(`SELECT title, status FROM progress_tasks WHERE slug='task-1'`).get() as {
+      title: string;
+      status: string;
+    };
+    expect(row.title).toBe('Local-title');
+    expect(row.status).toBe('executing');
+  });
+
+  it('applies a delete by removing the row and stamping tombstone', () => {
+    seedTask('task-del');
+    engine.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-del',
+      opType: 'update',
+      columns: { title: 'Exists' },
+    });
+
+    const del: Op = {
+      hlc: '00000000000009999999.00000000.bbbbbbbb',
+      originPeerId: 'peer-b',
+      tableName: 'progress_tasks',
+      pk: 'task-del',
+      opType: 'delete',
+      payload: {},
+    };
+    engine.applyRemoteOp(del);
+
+    const row = sqlite.prepare(`SELECT * FROM progress_tasks WHERE slug='task-del'`).get();
+    expect(row).toBeUndefined();
+
+    const tombstone = sqlite
+      .prepare(`SELECT * FROM row_meta WHERE pk='task-del' AND column_name='__deleted__'`)
+      .get();
+    expect(tombstone).toBeDefined();
+  });
+
+  it('is idempotent — applying same op twice is safe', () => {
+    const op: Op = {
+      hlc: '00000000000000099999.00000000.bbbbbbbb',
+      originPeerId: 'peer-b',
+      tableName: 'progress_tasks',
+      pk: 'task-idem',
+      opType: 'insert',
+      payload: {
+        slug: { value: 'task-idem', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        title: { value: 'Idempotent', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        status: { value: 'backlog', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        priority: { value: 'medium', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        created_at: { value: '2026-04-24T00:00:00Z', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+        updated_at: { value: '2026-04-24T00:00:00Z', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+      },
+    };
+
+    engine.applyRemoteOp(op);
+    engine.applyRemoteOp(op);
+
+    const count = sqlite.prepare(`SELECT COUNT(*) as c FROM op_log WHERE pk='task-idem'`).get() as {
+      c: number;
+    };
+    expect(count.c).toBe(1);
+  });
+});

--- a/tests/integration/peers/replication-engine.test.ts
+++ b/tests/integration/peers/replication-engine.test.ts
@@ -1,12 +1,14 @@
+import { resolve } from 'node:path';
+
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { Op } from '@shared/replication/op-types';
 
 import * as schema from '@main/db/schema';
 import { createReplicationEngine, type ReplicationEngine } from '@main/features/peers/replication-engine';
-import type { Op } from '@shared/replication/op-types';
 
 let sqlite: Database.Database;
 let db: ReturnType<typeof drizzle<typeof schema>>;

--- a/tests/integration/peers/replication-engine.test.ts
+++ b/tests/integration/peers/replication-engine.test.ts
@@ -155,6 +155,20 @@ describe('ReplicationEngine.applyRemoteOp', () => {
     expect(tombstone).toBeDefined();
   });
 
+  it('rejects ops with invalid column names', () => {
+    const op: Op = {
+      hlc: '00000000000000099999.00000000.bbbbbbbb',
+      originPeerId: 'peer-b',
+      tableName: 'progress_tasks',
+      pk: 'task-bad',
+      opType: 'insert',
+      payload: {
+        'title"; DROP TABLE progress_tasks; --': { value: 'x', hlc: '00000000000000099999.00000000.bbbbbbbb' },
+      },
+    };
+    expect(() => engine.applyRemoteOp(op)).toThrow(/invalid column name/);
+  });
+
   it('is idempotent — applying same op twice is safe', () => {
     const op: Op = {
       hlc: '00000000000000099999.00000000.bbbbbbbb',

--- a/tests/integration/peers/schema.test.ts
+++ b/tests/integration/peers/schema.test.ts
@@ -1,0 +1,94 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle>;
+
+beforeEach(() => {
+  sqlite = new Database(':memory:');
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+});
+
+afterEach(() => sqlite.close());
+
+describe('peers schema migration', () => {
+  it('creates op_log table', () => {
+    const rows = sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='op_log'")
+      .all();
+    expect(rows).toHaveLength(1);
+  });
+
+  it('creates row_meta table', () => {
+    const rows = sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='row_meta'")
+      .all();
+    expect(rows).toHaveLength(1);
+  });
+
+  it('op_log has unique index on (origin_peer_id, hlc)', () => {
+    sqlite
+      .prepare(
+        `INSERT INTO op_log (hlc, origin_peer_id, table_name, pk, op_type, payload, applied_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        '00000000000000000001.00000000.aaaaaaaa',
+        'peer-a',
+        'progress_tasks',
+        'task-1',
+        'insert',
+        '{}',
+        Date.now(),
+      );
+
+    expect(() =>
+      sqlite
+        .prepare(
+          `INSERT INTO op_log (hlc, origin_peer_id, table_name, pk, op_type, payload, applied_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          '00000000000000000001.00000000.aaaaaaaa',
+          'peer-a',
+          'progress_tasks',
+          'task-1',
+          'insert',
+          '{}',
+          Date.now(),
+        ),
+    ).toThrow(/UNIQUE/);
+  });
+
+  it('row_meta has composite PK on (table_name, pk, column_name)', () => {
+    sqlite
+      .prepare(
+        `INSERT INTO row_meta (table_name, pk, column_name, hlc, origin_peer_id) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        'progress_tasks',
+        'task-1',
+        'title',
+        '00000000000000000001.00000000.aaaaaaaa',
+        'peer-a',
+      );
+
+    expect(() =>
+      sqlite
+        .prepare(
+          `INSERT INTO row_meta (table_name, pk, column_name, hlc, origin_peer_id) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'progress_tasks',
+          'task-1',
+          'title',
+          '00000000000000000002.00000000.aaaaaaaa',
+          'peer-b',
+        ),
+    ).toThrow(/PRIMARY KEY|UNIQUE/);
+  });
+});

--- a/tests/integration/peers/schema.test.ts
+++ b/tests/integration/peers/schema.test.ts
@@ -1,7 +1,8 @@
+import { resolve } from 'node:path';
+
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 let sqlite: Database.Database;

--- a/tests/integration/peers/sync-tables.test.ts
+++ b/tests/integration/peers/sync-tables.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { SYNC_TABLES, isSyncTable } from '@shared/replication/sync-tables';
+
+describe('SYNC_TABLES', () => {
+  it('includes progress_tasks in phase 1', () => {
+    expect(SYNC_TABLES).toContain('progress_tasks');
+  });
+
+  it('isSyncTable returns true for allowlisted tables', () => {
+    expect(isSyncTable('progress_tasks')).toBe(true);
+  });
+
+  it('isSyncTable returns false for non-allowlisted tables', () => {
+    expect(isSyncTable('bus_events')).toBe(false);
+    expect(isSyncTable('sessions')).toBe(false);
+    expect(isSyncTable('op_log')).toBe(false);
+  });
+});

--- a/tests/integration/peers/sync-tables.test.ts
+++ b/tests/integration/peers/sync-tables.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { SYNC_TABLES, isSyncTable } from '@shared/replication/sync-tables';
+import { SYNC_TABLES, SYNC_TABLE_PK, isSyncTable } from '@shared/replication/sync-tables';
 
 describe('SYNC_TABLES', () => {
   it('includes progress_tasks in phase 1', () => {
@@ -15,5 +15,9 @@ describe('SYNC_TABLES', () => {
     expect(isSyncTable('bus_events')).toBe(false);
     expect(isSyncTable('sessions')).toBe(false);
     expect(isSyncTable('op_log')).toBe(false);
+  });
+
+  it('SYNC_TABLE_PK maps progress_tasks to slug', () => {
+    expect(SYNC_TABLE_PK.progress_tasks).toBe('slug');
   });
 });

--- a/tests/integration/peers/ws-roundtrip.test.ts
+++ b/tests/integration/peers/ws-roundtrip.test.ts
@@ -1,0 +1,128 @@
+// tests/integration/peers/ws-roundtrip.test.ts
+import { resolve } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as schema from '@main/db/schema';
+import { createReplicationEngine, type ReplicationEngine } from '@main/features/peers/replication-engine';
+import { createWsTransport, type WsTransport } from '@main/features/peers/ws-transport';
+
+async function waitFor<T>(fn: () => T | undefined, timeoutMs = 3000): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const v = fn();
+    if (v !== undefined) return v;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error('waitFor timed out');
+}
+
+describe('ws-transport roundtrip', () => {
+  let sqliteA: Database.Database;
+  let sqliteB: Database.Database;
+  let engineA: ReplicationEngine;
+  let engineB: ReplicationEngine;
+  let transportA: WsTransport;
+  let transportB: WsTransport;
+
+  beforeEach(async () => {
+    sqliteA = new Database(':memory:');
+    sqliteB = new Database(':memory:');
+    const dbA = drizzle(sqliteA, { schema });
+    const dbB = drizzle(sqliteB, { schema });
+    migrate(dbA, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+    migrate(dbB, { migrationsFolder: resolve(__dirname, '../../../drizzle') });
+
+    engineA = createReplicationEngine({ db: dbA, peerIdShort: 'aaaaaaaa', peerIdFull: 'peer-a' });
+    engineB = createReplicationEngine({ db: dbB, peerIdShort: 'bbbbbbbb', peerIdFull: 'peer-b' });
+
+    transportA = await createWsTransport({ engine: engineA, listenPort: 0, remoteUrl: '' });
+    const portA = transportA.listenPort();
+    transportB = await createWsTransport({
+      engine: engineB,
+      listenPort: 0,
+      remoteUrl: `ws://127.0.0.1:${String(portA)}`,
+    });
+
+    await waitFor(() => (transportB.isConnected() && transportA.isConnected() ? true : undefined));
+  });
+
+  afterEach(async () => {
+    await transportA.close();
+    await transportB.close();
+    sqliteA.close();
+    sqliteB.close();
+  });
+
+  it('establishes a connection', () => {
+    expect(transportA.isConnected()).toBe(true);
+    expect(transportB.isConnected()).toBe(true);
+  });
+
+  it('A write appears on B within 1s', async () => {
+    // Note: recordLocalWrite is metadata-only. On peer A we must also write to the user
+    // table. On peer B, applyRemoteOp will write to B's user table automatically.
+    sqliteA
+      .prepare(
+        `INSERT INTO progress_tasks (slug, title, status, priority, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run('task-over-ws', 'Hello from A', 'backlog', 'medium', '2026-04-24T00:00:00Z', '2026-04-24T00:00:00Z');
+
+    engineA.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-over-ws',
+      opType: 'insert',
+      columns: {
+        slug: 'task-over-ws',
+        title: 'Hello from A',
+        status: 'backlog',
+        priority: 'medium',
+        created_at: '2026-04-24T00:00:00Z',
+        updated_at: '2026-04-24T00:00:00Z',
+      },
+    });
+
+    const row = await waitFor(() =>
+      sqliteB.prepare(`SELECT title FROM progress_tasks WHERE slug='task-over-ws'`).get() as
+        | { title: string }
+        | undefined,
+    );
+    expect(row.title).toBe('Hello from A');
+  });
+
+  it('B write appears on A within 1s', async () => {
+    sqliteB
+      .prepare(
+        `INSERT INTO progress_tasks (slug, title, status, priority, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run('task-from-b', 'Hello from B', 'backlog', 'medium', '2026-04-24T00:00:00Z', '2026-04-24T00:00:00Z');
+
+    engineB.recordLocalWrite({
+      tableName: 'progress_tasks',
+      pk: 'task-from-b',
+      opType: 'insert',
+      columns: {
+        slug: 'task-from-b',
+        title: 'Hello from B',
+        status: 'backlog',
+        priority: 'medium',
+        created_at: '2026-04-24T00:00:00Z',
+        updated_at: '2026-04-24T00:00:00Z',
+      },
+    });
+
+    const row = await waitFor(() =>
+      sqliteA.prepare(`SELECT title FROM progress_tasks WHERE slug='task-from-b'`).get() as
+        | { title: string }
+        | undefined,
+    );
+    expect(row.title).toBe('Hello from B');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the P2P sync migration (spec: `docs/superpowers/specs/2026-04-24-p2p-sync-design.md`). Proves the SQLite + op-log + HLC + column-level LWW replication stack on `progress_tasks` with a hardcoded-address WebSocket transport. **No user-facing behavior change**: the transport only activates when `ADC_PEER_PORT` is set.

Retires no existing code. Hub sync (v0.2.0) continues to work unchanged. Phases 2-5 will add schema sweep, mDNS/PIN pairing + TLS, extend to all sync-scope tables, and finally retire `hub/`.

## What ships

- `src/shared/replication/{sync-tables,hlc,op-types}.ts` — primitives
- `src/main/features/peers/{schema,op-log,lww-merge,replication-engine,ws-transport,peer-config}.ts` — core
- `drizzle/0026_op_log_and_row_meta.sql` — new tables (`op_log`, `row_meta`)
- `src/main/features/progress/progress-service.ts` — 4 new `recordLocalWrite` call sites (create/update/archive/delete)
- `src/main/bootstrap/service-registry.ts` — constructs engine; fire-and-forget WS transport when port is set
- `docs/peers/phase1-dev-harness.md` — manual two-instance verification steps

## Scope boundary — explicitly NOT in this PR

- mDNS discovery (Phase 3)
- PIN pairing / Ed25519 exchange (Phase 3)
- TLS + fingerprint pinning (Phase 3)
- Schema-hash handshake (Phase 2)
- Sync for tables other than `progress_tasks` (Phase 4)
- Hub deletion (Phase 5)
- Op-log GC (Phase 4)

## Test plan

- [x] 56/56 integration tests pass (`npx vitest run --config vitest.integration.config.ts tests/integration/peers`)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] Lint clean on all new/modified files
- [ ] **Manual two-instance verification pending** — follow `docs/peers/phase1-dev-harness.md`: run ADC-Dev (port 7701) + ADC-Local (port 7702) with peer env vars, create/edit/archive/delete a task on one, confirm it appears on the other within ~1s.

## Known follow-ups (flagged by code review, deferred)

- `Array.isArray(ops)` guard in ws-transport for malformed peer frames (minor — Phase 3 pair-security takes this seriously)
- Fire-and-forget WS transport: no cleanup handle held by service-registry (minor; Phase 3 adds proper lifecycle)
- `archiveTask` not covered by the new progress-service replication test (low risk — functionally identical to `updateTask`)

## Commits

17 commits on `feature/p2p-sync-phase1`, tagged `p2p-phase1-done` at `c519696a`.